### PR TITLE
Highlight npub/etc references in the textarea

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ dependencies = [
  "image",
  "lazy_static",
  "linkify",
+ "memoize",
  "nostr-types",
  "parking_lot",
  "rand 0.8.5",
@@ -2189,6 +2190,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memoize"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25d125e4063f313300d87c8f658e5b3d69257095df9a4221c12ba50b0421bff"
+dependencies = [
+ "lazy_static",
+ "memoize-inner",
+]
+
+[[package]]
+name = "memoize-inner"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7d5160e6ffcc59d4c571c38238ec5b7065bc91a5a24f511988dabcddda723"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ http = "0.2"
 image = { version = "0.24", features = [ "png", "jpeg" ] }
 lazy_static = "1.4"
 linkify = "0.9"
+memoize = "0.3"
 nostr-types = { git = "https://github.com/mikedilger/nostr-types" }
 parking_lot = "0.12"
 rand = "0.8"

--- a/src/ui/feed.rs
+++ b/src/ui/feed.rs
@@ -2,7 +2,7 @@ use super::{GossipUi, Page};
 use crate::comms::ToOverlordMessage;
 use crate::feed::FeedKind;
 use crate::globals::{Globals, GLOBALS};
-use crate::tags::keys_from_text;
+use crate::tags::{keys_from_text, textarea_highlighter};
 use crate::ui::widgets::CopyButton;
 use crate::AVATAR_SIZE_F32;
 use eframe::egui;
@@ -185,11 +185,18 @@ fn real_posting_area(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
         });
 
         // Text area
+        let mut layouter = |ui: &Ui, text: &str, wrap_width: f32| {
+            let mut layout_job = textarea_highlighter(text.to_owned());
+            layout_job.wrap.max_width = wrap_width;
+            ui.fonts().layout_job(layout_job)
+        };
+
         ui.add(
             TextEdit::multiline(&mut app.draft)
                 .hint_text("Type your message here")
                 .desired_width(f32::INFINITY)
-                .lock_focus(true),
+                .lock_focus(true)
+                .layouter(&mut layouter),
         );
     });
 


### PR DESCRIPTION
For now, just formatting the text differently. 

As you can see, I am not a designer, so feel free to change this, but I kinda like it.

I am not sure it will be possible to actually rewrite it without causing glitches, but I also didn't try.

![2023-01-18-112943_951x545_scrot](https://user-images.githubusercontent.com/1653275/213199131-6f27561e-96a2-45c4-ab8a-3468fac02b4d.png)
![2023-01-18-113213_788x247_scrot](https://user-images.githubusercontent.com/1653275/213199147-b53ce89d-7d92-4381-9e73-628ca726f020.png)