### PR TITLE
github action to build every commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build every commit
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release
+      - if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          path: target/release/gossip.exe
+          name: gossip.exe
+      - if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          path: target/release/gossip*
+          name: gossip_linux
+      - if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          path: target/release/gossip*
+          name: gossip_macos


### PR DESCRIPTION
It builds for Linux, Mac and Windows and makes the binaries available for download. Includes caching builds.

See an example here: https://github.com/fiatjaf/gossip/actions/runs/3999588145