### PR TITLE
Avoid subtract with overflow.

### DIFF
--- a/src/relay_assignment.rs
+++ b/src/relay_assignment.rs
@@ -262,6 +262,9 @@ impl RelayPicker {
         for (pubkey, count) in self.pubkey_counts.iter_mut() {
             if over_covered_public_keys.contains(pubkey) {
                 covered_public_keys.push(pubkey.clone());
+                if count.eq(&&mut 0u8) {
+                    continue;
+                }
                 *count -= 1;
                 changed = true;
             }


### PR DESCRIPTION
Recently running gossip and I encountered the following "subtract with overflow" panic.
This commit fixed the issue for me. I apologize if this is not a holistic fix, I just patched it quickly over breakfast.

```
./run.sh
   Compiling gossip v0.3.1-unstable (/Users/garykrause/repos/gossip)
    Finished dev [unoptimized + debuginfo] target(s) in 6.86s
     Running `target/debug/gossip`
 INFO src/db/mod.rs:137: Database is at version 21
DEBUG src/ui/mod.rs:148: Pixels per point: 2
 INFO src/overlord/mod.rs:157: Loaded 236 reply related events from the database
 INFO src/overlord/mod.rs:196: Loaded 0 feed related events from the database
 INFO src/overlord/mod.rs:209: Loaded 4 relay list events from the database
 INFO src/relay_assignment.rs:193: Searching for the best relay among 380 for 374 people
thread '<unnamed>' panicked at 'attempt to subtract with overflow', src/relay_assignment.rs:265:17
stack backtrace:
   0: rust_begin_unwind
             at /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/panicking.rs:65:14
   2: core::panicking::panic
             at /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/panicking.rs:115:5
   3: gossip::relay_assignment::RelayPicker::consume
             at ./src/relay_assignment.rs:265:17
   4: gossip::relay_assignment::RelayPicker::pick
             at ./src/relay_assignment.rs:243:9
   5: gossip::overlord::Overlord::pick_relays::{{closure}}
             at ./src/overlord/mod.rs:278:19
   6: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/future/mod.rs:91:19
   7: gossip::overlord::Overlord::run_inner::{{closure}}
             at ./src/overlord/mod.rs:218:31
   8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/future/mod.rs:91:19
   9: gossip::overlord::Overlord::run::{{closure}}
             at ./src/overlord/mod.rs:50:41
  10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/future/mod.rs:91:19
  11: gossip::tokio_main::{{closure}}
             at ./src/main.rs:94:19
  12: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/future/mod.rs:91:19
  13: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /Users/garykrause/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.2/src/runtime/park.rs:283:63
  14: tokio::runtime::coop::with_budget
             at /Users/garykrause/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.2/src/runtime/coop.rs:102:5
  15: tokio::runtime::coop::budget
             at /Users/garykrause/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.2/src/runtime/coop.rs:68:5
  16: tokio::runtime::park::CachedParkThread::block_on
             at /Users/garykrause/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.2/src/runtime/park.rs:283:31
  17: tokio::runtime::context::BlockingRegionGuard::block_on
             at /Users/garykrause/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.2/src/runtime/context.rs:315:13
  18: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /Users/garykrause/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.2/src/runtime/scheduler/multi_thread/mod.rs:66:9
  19: tokio::runtime::runtime::Runtime::block_on
             at /Users/garykrause/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.2/src/runtime/runtime.rs:284:45
  20: gossip::main::{{closure}}
             at ./src/main.rs:66:9
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```