### PR TITLE
View raw notes as prettified JSON instead of a long JSON string

### DIFF
--- a/src/ui/feed/mod.rs
+++ b/src/ui/feed/mod.rs
@@ -458,7 +458,7 @@ fn render_post_inner(
         // MAIN CONTENT
         ui.horizontal_wrapped(|ui| {
             if app.render_raw == Some(event.id) {
-                ui.label(serde_json::to_string(&event).unwrap());
+                ui.label(serde_json::to_string_pretty(&event).unwrap());
             } else if app.render_qr == Some(event.id) {
                 app.render_qr(ui, ctx, "feedqr", event.content.trim());
             } else if event.kind == EventKind::Repost {


### PR DESCRIPTION
When pressing the "Raw" button in the "Feed" tab, display the JSON string with newlines and indentation, instead of the simple JSON string