### PR TITLE
add jeremyd to authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gossip"
 version = "0.4.90-unstable"
 description = "A social media client for nostr"
-authors = ["Mike Dilger <mike@mikedilger.com>", "fiatjaf <fiatjaf@gmail.com>", "Nate Levin <nate@ezicheq.com>", "Nethanja Focking <nethanja@nethanja.de>"]
+authors = ["Mike Dilger <mike@mikedilger.com>", "fiatjaf <fiatjaf@gmail.com>", "Nate Levin <nate@ezicheq.com>", "Nethanja Focking <nethanja@nethanja.de>", "jeremyd (@jeremyd)"]
 license = "MIT"
 repository = "https://github.com/mikedilger/gossip"
 homepage = "https://github.com/mikedilger/gossip"


### PR DESCRIPTION
Hi Mike,
Thanks for asking if I wanted to be in the authors list.  Sure!  

Instead of an email I'd like to just use my github handle @jeremyd.  I looked around and made sure this wouldn't screw up cargo.  It seems that it should be ok, according to this:

https://github.com/rust-lang/cargo/issues/5339