### PR TITLE
Restyle the default theme's main feed and top

### DIFF
--- a/src/ui/feed/mod.rs
+++ b/src/ui/feed/mod.rs
@@ -72,11 +72,12 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
             }
         }
     });
-    ui.separator();
+
+    ui.add_space(10.0);
 
     post::posting_area(app, ctx, frame, ui);
 
-    ui.separator();
+    ui.add_space(10.0);
 
     match feed_kind {
         FeedKind::General => {
@@ -290,10 +291,7 @@ fn render_post_actual(
         .fill(theme.feed_frame_fill(is_new, is_main_event))
         .stroke(theme.feed_frame_stroke(is_new, is_main_event))
         .show(ui, |ui| {
-            if is_main_event {
-                thin_red_separator(ui);
-            }
-
+            
             ui.add_space(4.0);
 
             ui.horizontal_wrapped(|ui| {
@@ -313,9 +311,6 @@ fn render_post_actual(
                 }
             });
 
-            if is_main_event {
-                thin_red_separator(ui);
-            }
         });
 
     // Mark post as viewed if hovered AND we are not scrolling
@@ -512,7 +507,7 @@ fn render_post_inner(
                         None => DbPerson::new(inner_event.pubkey.into()),
                     };
                     ui.vertical(|ui| {
-                        thin_blue_separator(ui);
+                        thin_repost_separator(ui);
                         ui.add_space(4.0);
                         ui.horizontal_wrapped(|ui| {
                             render_post_inner(
@@ -525,7 +520,7 @@ fn render_post_inner(
                                 false,
                             );
                         });
-                        thin_blue_separator(ui);
+                        thin_repost_separator(ui);
                     });
                 } else if event.content.is_empty() {
                     content::render_content(
@@ -664,22 +659,32 @@ fn render_post_inner(
     });
 }
 
-fn thin_red_separator(ui: &mut Ui) {
+fn thin_highlight_separator(ui: &mut Ui) {
+    let color = if ui.visuals().dark_mode {
+        Color32::LIGHT_YELLOW
+    } else {
+        Color32::LIGHT_GREEN
+    };
     thin_separator(
         ui,
         Stroke {
-            width: 1.0,
-            color: Color32::from_rgb(160, 0, 0),
+            width: 2.0,
+            color: color,
         },
     );
 }
 
-fn thin_blue_separator(ui: &mut Ui) {
+fn thin_repost_separator(ui: &mut Ui) {
+    let color = if ui.visuals().dark_mode {
+        Color32::from_gray(80)
+    } else {
+        Color32::from_gray(200)
+    };
     thin_separator(
         ui,
         Stroke {
             width: 1.0,
-            color: Color32::from_rgb(0, 0, 160),
+            color: color,
         },
     );
 }

--- a/src/ui/feed/post.rs
+++ b/src/ui/feed/post.rs
@@ -109,8 +109,10 @@ fn real_posting_area(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
             .layouter(&mut layouter),
     );
 
+    ui.add_space(4.0);
     ui.horizontal(|ui| {
         ui.with_layout(Layout::right_to_left(Align::TOP), |ui| {
+            ui.add_space(12.0);
             if ui.button("Send").clicked() && !app.draft.is_empty() {
                 match app.replying_to {
                     Some(replying_to_id) => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -358,6 +358,7 @@ impl eframe::App for GossipUi {
         }
 
         egui::TopBottomPanel::top("menu").show(ctx, |ui| {
+            ui.add_space(6.0);
             ui.horizontal(|ui| {
                 let back_label_text = RichText::new("‹ Back");
                 let label = if self.history.is_empty() {
@@ -435,6 +436,7 @@ impl eframe::App for GossipUi {
                 }
                 ui.separator();
             });
+            ui.add_space(4.0);
         });
 
         egui::TopBottomPanel::bottom("status").show(ctx, |ui| {

--- a/src/ui/theme/gossip.rs
+++ b/src/ui/theme/gossip.rs
@@ -110,34 +110,34 @@ impl Theme for Gossip {
                     noninteractive: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(27),
                         bg_fill: Color32::from_white_alpha(8),
-                        bg_stroke: Stroke::new(1.0, Color32::from_gray(72)), // separators, borders
+                        bg_stroke: Stroke::new(1.0, Color32::from_gray(30)), // separators, borders
                         fg_stroke: Stroke::new(1.0, Color32::from_gray(190)), // normal text color
                         rounding: Rounding::same(2.0),
                         expansion: 0.0,
                     },
                     inactive: WidgetVisuals {
-                        weak_bg_fill: Color32::from_gray(60),
+                        weak_bg_fill: Color32::from_gray(20),
                         bg_fill: Color32::from_white_alpha(8),
-                        bg_stroke: Stroke::new(1.0, Color32::from_gray(72)), // separators, borders
-                        fg_stroke: Stroke::new(1.0, Color32::from_gray(190)), // button text
+                        bg_stroke: Stroke::new(0.0, Color32::from_gray(72)), // separators, borders
+                        fg_stroke: Stroke::new(1.0, Color32::from_gray(120)), // button text
                         rounding: Rounding::same(2.0),
-                        expansion: 0.0,
+                        expansion: 2.0,
                     },
                     hovered: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(70),
                         bg_fill: Color32::from_gray(70),
-                        bg_stroke: Stroke::new(1.0, Color32::from_gray(150)), // e.g. hover over window edge or button
+                        bg_stroke: Stroke::new(0.0, Color32::from_gray(150)), // e.g. hover over window edge or button
                         fg_stroke: Stroke::new(1.5, Color32::from_gray(240)),
                         rounding: Rounding::same(3.0),
-                        expansion: 1.0,
+                        expansion: 2.0,
                     },
                     active: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(55),
                         bg_fill: Color32::from_gray(55),
-                        bg_stroke: Stroke::new(1.0, Color32::WHITE),
-                        fg_stroke: Stroke::new(2.0, Color32::WHITE),
+                        bg_stroke: Stroke::new(0.0, Color32::WHITE),
+                        fg_stroke: Stroke::new(2.0, Color32::from_gray(160)),
                         rounding: Rounding::same(2.0),
-                        expansion: 1.0,
+                        expansion: 2.0,
                     },
                     open: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(27),
@@ -151,7 +151,7 @@ impl Theme for Gossip {
 
                 // Background colors
                 window_fill: Color32::from_gray(0x24),
-                panel_fill: Color32::from_gray(0x24),
+                panel_fill: Color32::from_gray(10),
                 faint_bg_color: Color32::from_gray(0x14),
                 extreme_bg_color: Color32::from_gray(0),
                 code_bg_color: Color32::from_gray(64),
@@ -164,8 +164,8 @@ impl Theme for Gossip {
                 hyperlink_color: Color32::from_rgb(0x73, 0x95, 0xae), // light blue?
 
                 selection: Selection {
-                    bg_fill: Color32::from_rgb(0x57, 0x4a, 0x40),
-                    stroke: Stroke::new(1.0, Color32::from_gray(230)),
+                    bg_fill: Color32::from_gray(40),
+                    stroke: Stroke::new(0.0, Color32::from_gray(220))
                 },
 
                 window_shadow: Shadow::big_dark(),
@@ -190,7 +190,7 @@ impl Theme for Gossip {
                     noninteractive: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(248),
                         bg_fill: Color32::from_black_alpha(20),
-                        bg_stroke: Stroke::new(1.0, Color32::from_gray(192)),
+                        bg_stroke: Stroke::new(1.0, Color32::from_gray(230)),
                         fg_stroke: Stroke::new(1.0, Color32::from_gray(80)), // normal text color
                         rounding: Rounding::same(2.0),
                         expansion: 0.0,
@@ -198,26 +198,26 @@ impl Theme for Gossip {
                     inactive: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(230),
                         bg_fill: Color32::from_black_alpha(20),
-                        bg_stroke: Stroke::new(1.0, Color32::from_gray(192)),
+                        bg_stroke: Stroke::new(0.0, Color32::from_gray(192)),
                         fg_stroke: Stroke::new(1.0, Color32::from_gray(60)), // button text
                         rounding: Rounding::same(2.0),
-                        expansion: 0.0,
+                        expansion: 2.0,
                     },
                     hovered: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(220),
                         bg_fill: Color32::from_gray(220),
-                        bg_stroke: Stroke::new(1.0, Color32::from_gray(105)), // e.g. hover over window edge or button
+                        bg_stroke: Stroke::new(0.0, Color32::from_gray(105)), // e.g. hover over window edge or button
                         fg_stroke: Stroke::new(1.5, Color32::BLACK),
                         rounding: Rounding::same(3.0),
-                        expansion: 1.0,
+                        expansion: 2.0,
                     },
                     active: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(165),
                         bg_fill: Color32::from_gray(165),
-                        bg_stroke: Stroke::new(1.0, Color32::BLACK),
+                        bg_stroke: Stroke::new(0.0, Color32::BLACK),
                         fg_stroke: Stroke::new(2.0, Color32::BLACK),
                         rounding: Rounding::same(2.0),
-                        expansion: 1.0,
+                        expansion: 2.0,
                     },
                     open: WidgetVisuals {
                         weak_bg_fill: Color32::from_gray(220),
@@ -244,8 +244,8 @@ impl Theme for Gossip {
                 hyperlink_color: Color32::from_rgb(0x55, 0x7a, 0x95), // DONE
 
                 selection: Selection {
-                    bg_fill: Color32::from_rgb(0xb1, 0xa2, 0x96), // DONE
-                    stroke: Stroke::new(1.0, Color32::from_rgb(0x5d, 0x5c, 0x61)), // DONE
+                    bg_fill: Color32::from_gray(220), // DONE
+                    stroke: Stroke::new(1.0, Color32::from_gray(40)), // DONE
                 },
 
                 window_shadow: Shadow::big_light(),
@@ -363,36 +363,43 @@ impl Theme for Gossip {
     // feed styling
     fn feed_scroll_fill(&self) -> eframe::egui::Color32 {
         if self.dark_mode {
-            Color32::BLACK
+            Color32::from_gray(0)
         } else {
-            Color32::WHITE
+            Color32::from_gray(240)
         }
     }
     fn feed_post_separator_stroke(&self) -> eframe::egui::Stroke {
         eframe::egui::Stroke::default()
     }
     fn feed_frame_inner_margin(&self) -> eframe::egui::Margin {
-        eframe::egui::Margin::default()
+        eframe::egui::Margin::symmetric(10.0, 10.0)
     }
     fn feed_frame_outer_margin(&self) -> eframe::egui::Margin {
-        eframe::egui::Margin::default()
+        eframe::egui::Margin::symmetric(0.0, 0.0)
     }
     fn feed_frame_rounding(&self) -> eframe::egui::Rounding {
-        eframe::egui::Rounding::default()
+        eframe::egui::Rounding::same(4.0)
     }
     fn feed_frame_shadow(&self) -> eframe::epaint::Shadow {
         eframe::epaint::Shadow::default()
     }
-    fn feed_frame_fill(&self, is_new: bool, _: bool) -> eframe::egui::Color32 {
-        if is_new {
+    fn feed_frame_fill(&self, is_new: bool, is_main_event: bool) -> eframe::egui::Color32 {
+
+        if is_main_event {
             if self.dark_mode {
-                Color32::from_rgb(60, 0, 0)
+                Color32::from_rgb(16, 23, 33)
             } else {
-                Color32::LIGHT_YELLOW
+                Color32::from_rgb(246, 252, 227)
+            }
+        } else if is_new {
+            if self.dark_mode {
+                Color32::from_rgb(34, 28, 38)
+            } else {
+                Color32::from_rgb(255, 255, 237)
             }
         } else {
             if self.dark_mode {
-                Color32::BLACK
+                Color32::from_rgb(30, 30, 30)
             } else {
                 Color32::WHITE
             }


### PR DESCRIPTION
Basic restyle to improve the UI:

* Add a separator to the feed element
* Add some spacing around the feed element
* Add some spacing above and below the menu items
* Remove some menu separators
* Replace the main event separators with a coloured bg

Preview, light version:
<img width="975" alt="Screenshot 2023-02-28 alle 22 53 24" src="https://user-images.githubusercontent.com/89577423/221990113-baef02d8-2c19-429f-b46f-1871bbd3d180.png">
<img width="975" alt="Screenshot 2023-02-28 alle 22 53 53" src="https://user-images.githubusercontent.com/89577423/221990127-edc1ad8e-7323-4d9c-b692-ed3cc0c1e7a2.png">

And dark version:
<img width="975" alt="Screenshot 2023-02-28 alle 22 54 23" src="https://user-images.githubusercontent.com/89577423/221990152-7621b2cf-1f9a-4ccb-ad6c-7be9517389f4.png">
<img width="975" alt="Screenshot 2023-02-28 alle 22 54 16" src="https://user-images.githubusercontent.com/89577423/221990181-4ec16414-9621-40e3-8ae4-ce0fca95c38e.png">
