### PR TITLE
Split the Following section in Main feed and Conversations

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,7 +26,6 @@ pub const DEFAULT_REPOSTS: bool = true;
 pub const DEFAULT_LOAD_AVATARS: bool = true;
 pub const DEFAULT_CHECK_NIP05: bool = true;
 pub const DEFAULT_DIRECT_REPLIES_ONLY: bool = true;
-pub const DEFAULT_REPLIES_IN_FOLLOWS: bool = true;
 pub const DEFAULT_DIRECT_MESSAGES: bool = true;
 pub const DEFAULT_AUTOMATICALLY_FETCH_METADATA: bool = true;
 
@@ -51,7 +50,6 @@ pub struct Settings {
     pub load_avatars: bool,
     pub check_nip05: bool,
     pub direct_replies_only: bool,
-    pub replies_in_follows: bool,
     pub direct_messages: bool,
     pub automatically_fetch_metadata: bool,
     pub delegatee_tag: String,
@@ -79,7 +77,6 @@ impl Default for Settings {
             load_avatars: DEFAULT_LOAD_AVATARS,
             check_nip05: DEFAULT_CHECK_NIP05,
             direct_replies_only: DEFAULT_DIRECT_REPLIES_ONLY,
-            replies_in_follows: DEFAULT_REPLIES_IN_FOLLOWS,
             direct_messages: DEFAULT_DIRECT_MESSAGES,
             automatically_fetch_metadata: DEFAULT_AUTOMATICALLY_FETCH_METADATA,
             delegatee_tag: String::new(),
@@ -161,7 +158,6 @@ impl Settings {
                 "load_avatars" => settings.load_avatars = numstr_to_bool(row.1),
                 "check_nip05" => settings.check_nip05 = numstr_to_bool(row.1),
                 "direct_replies_only" => settings.direct_replies_only = numstr_to_bool(row.1),
-                "replies_in_follows" => settings.replies_in_follows = numstr_to_bool(row.1),
                 "direct_messages" => settings.direct_messages = numstr_to_bool(row.1),
                 "automatically_fetch_metadata" => {
                     settings.automatically_fetch_metadata = numstr_to_bool(row.1)
@@ -206,7 +202,6 @@ impl Settings {
              ('load_avatars', ?),\
              ('check_nip05', ?),\
              ('direct_replies_only', ?),\
-             ('replies_in_follows', ?),\
              ('direct_messages', ?),\
              ('automatically_fetch_metadata', ?),\
              ('delegatee_tag', ?)",
@@ -230,7 +225,6 @@ impl Settings {
             bool_to_numstr(self.load_avatars),
             bool_to_numstr(self.check_nip05),
             bool_to_numstr(self.direct_replies_only),
-            bool_to_numstr(self.replies_in_follows),
             bool_to_numstr(self.direct_messages),
             bool_to_numstr(self.automatically_fetch_metadata),
             self.delegatee_tag,

--- a/src/ui/feed/mod.rs
+++ b/src/ui/feed/mod.rs
@@ -30,8 +30,18 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
     ui.horizontal(|ui| {
         if ui
             .add(SelectableLabel::new(
+                app.page == Page::Feed(FeedKind::Main),
+                "Main feed",
+            ))
+            .clicked()
+        {
+            app.set_page(Page::Feed(FeedKind::Main));
+        }
+        ui.separator();
+        if ui
+            .add(SelectableLabel::new(
                 app.page == Page::Feed(FeedKind::General),
-                "Following",
+                "Conversations",
             ))
             .clicked()
         {
@@ -80,6 +90,10 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
     ui.add_space(10.0);
 
     match feed_kind {
+        FeedKind::Main => {
+            let feed = GLOBALS.feed.get_main();
+            render_a_feed(app, ctx, frame, ui, feed, false, "main");
+        }
         FeedKind::General => {
             let feed = GLOBALS.feed.get_general();
             render_a_feed(app, ctx, frame, ui, feed, false, "general");

--- a/src/ui/help/mod.rs
+++ b/src/ui/help/mod.rs
@@ -133,7 +133,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                 ui.horizontal_wrapped(|ui| {
                     ui.label("On the");
                     if ui.link("Feed > Following").clicked() {
-                        app.set_page(Page::Feed(FeedKind::General));
+                        app.set_page(Page::Feed(FeedKind::Main));
                     }
                     ui.label("page, enjoy the feed.");
                 });
@@ -229,7 +229,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                 ui.horizontal_wrapped(|ui| {
                     ui.label("On the");
                     if ui.link("Feed > Following").clicked() {
-                        app.set_page(Page::Feed(FeedKind::General));
+                        app.set_page(Page::Feed(FeedKind::Main));
                     }
                     ui.label("page, enjoy the feed.");
                 });

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -224,7 +224,7 @@ impl GossipUi {
         let start_page = if GLOBALS.first_run.load(Ordering::Relaxed) {
             Page::HelpHelp
         } else {
-            Page::Feed(FeedKind::General)
+            Page::Feed(FeedKind::Main)
         };
 
         // Apply current theme
@@ -304,6 +304,9 @@ impl GossipUi {
         match &page {
             Page::Feed(FeedKind::General) => {
                 GLOBALS.feed.set_feed_to_general();
+            }
+            Page::Feed(FeedKind::Main) => {
+                GLOBALS.feed.set_feed_to_main();
             }
             Page::Feed(FeedKind::Replies) => {
                 GLOBALS.feed.set_feed_to_replies();
@@ -388,7 +391,7 @@ impl eframe::App for GossipUi {
                     ))
                     .clicked()
                 {
-                    self.set_page(Page::Feed(FeedKind::General));
+                    self.set_page(Page::Feed(FeedKind::Main));
                 }
                 ui.separator();
                 if ui

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -109,12 +109,6 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
 
                 ui.add_space(12.0);
 
-                ui.checkbox(
-                    &mut app.settings.replies_in_follows,
-                    "Include Replies in Following Feed",
-                )
-                    .on_hover_text("Takes effect when the feed refreshes.");
-
                 ui.add_space(12.0);
 
 


### PR DESCRIPTION
And remove the "Include Replies in Following Feed" option from the settings

@mikedilger I suppose it is necessary to add a rollback migration to clean up the "replies_in_follows" key in the settings, but I don't know how to do it :)

<img width="868" alt="image" src="https://user-images.githubusercontent.com/89577423/222504957-4aff6ada-674d-4cfc-9b9c-6cedee73c191.png">
