### PR TITLE
Split Inbox section in Inbox and Activity

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -25,7 +25,6 @@ pub const DEFAULT_REACTIONS: bool = true;
 pub const DEFAULT_REPOSTS: bool = true;
 pub const DEFAULT_LOAD_AVATARS: bool = true;
 pub const DEFAULT_CHECK_NIP05: bool = true;
-pub const DEFAULT_DIRECT_REPLIES_ONLY: bool = true;
 pub const DEFAULT_DIRECT_MESSAGES: bool = true;
 pub const DEFAULT_AUTOMATICALLY_FETCH_METADATA: bool = true;
 
@@ -49,7 +48,6 @@ pub struct Settings {
     pub reposts: bool,
     pub load_avatars: bool,
     pub check_nip05: bool,
-    pub direct_replies_only: bool,
     pub direct_messages: bool,
     pub automatically_fetch_metadata: bool,
     pub delegatee_tag: String,
@@ -76,7 +74,6 @@ impl Default for Settings {
             reposts: DEFAULT_REPOSTS,
             load_avatars: DEFAULT_LOAD_AVATARS,
             check_nip05: DEFAULT_CHECK_NIP05,
-            direct_replies_only: DEFAULT_DIRECT_REPLIES_ONLY,
             direct_messages: DEFAULT_DIRECT_MESSAGES,
             automatically_fetch_metadata: DEFAULT_AUTOMATICALLY_FETCH_METADATA,
             delegatee_tag: String::new(),
@@ -157,7 +154,6 @@ impl Settings {
                 "reposts" => settings.reposts = numstr_to_bool(row.1),
                 "load_avatars" => settings.load_avatars = numstr_to_bool(row.1),
                 "check_nip05" => settings.check_nip05 = numstr_to_bool(row.1),
-                "direct_replies_only" => settings.direct_replies_only = numstr_to_bool(row.1),
                 "direct_messages" => settings.direct_messages = numstr_to_bool(row.1),
                 "automatically_fetch_metadata" => {
                     settings.automatically_fetch_metadata = numstr_to_bool(row.1)
@@ -201,7 +197,6 @@ impl Settings {
              ('reposts', ?),\
              ('load_avatars', ?),\
              ('check_nip05', ?),\
-             ('direct_replies_only', ?),\
              ('direct_messages', ?),\
              ('automatically_fetch_metadata', ?),\
              ('delegatee_tag', ?)",
@@ -224,7 +219,6 @@ impl Settings {
             bool_to_numstr(self.reposts),
             bool_to_numstr(self.load_avatars),
             bool_to_numstr(self.check_nip05),
-            bool_to_numstr(self.direct_replies_only),
             bool_to_numstr(self.direct_messages),
             bool_to_numstr(self.automatically_fetch_metadata),
             self.delegatee_tag,

--- a/src/ui/feed/mod.rs
+++ b/src/ui/feed/mod.rs
@@ -57,6 +57,16 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
         {
             app.set_page(Page::Feed(FeedKind::Replies));
         }
+        ui.separator();
+        if ui
+            .add(SelectableLabel::new(
+                app.page == Page::Feed(FeedKind::Activity),
+                "Activity",
+            ))
+            .clicked()
+        {
+            app.set_page(Page::Feed(FeedKind::Activity));
+        }
         if matches!(feed_kind.clone(), FeedKind::Thread { .. }) {
             ui.separator();
             if ui
@@ -110,6 +120,19 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
             }
             let feed = GLOBALS.feed.get_replies();
             render_a_feed(app, ctx, frame, ui, feed, false, "replies");
+        }
+        FeedKind::Activity => {
+            if GLOBALS.signer.public_key().is_none() {
+                ui.horizontal_wrapped(|ui| {
+                    ui.label("You need to ");
+                    if ui.link("setup an identity").clicked() {
+                        app.set_page(Page::YourKeys);
+                    }
+                    ui.label(" to see any replies to that identity.");
+                });
+            }
+            let feed = GLOBALS.feed.get_activity();
+            render_a_feed(app, ctx, frame, ui, feed, false, "activity");
         }
         FeedKind::Thread { id, .. } => {
             if let Some(parent) = GLOBALS.feed.get_thread_parent() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -311,6 +311,9 @@ impl GossipUi {
             Page::Feed(FeedKind::Replies) => {
                 GLOBALS.feed.set_feed_to_replies();
             }
+            Page::Feed(FeedKind::Activity) => {
+                GLOBALS.feed.set_feed_to_activity();
+            }
             Page::Feed(FeedKind::Thread { id, referenced_by }) => {
                 GLOBALS.feed.set_feed_to_thread(*id, *referenced_by);
             }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -100,12 +100,6 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                 );
 
                 ui.checkbox(
-                    &mut app.settings.direct_replies_only,
-                    "Show Direct Replies Only in your Inbox",
-                )
-                    .on_hover_text("Takes effect when the feed refreshes.");
-
-                ui.checkbox(
                     &mut app.settings.direct_messages,
                     "Show Direct Messages",
                 )


### PR DESCRIPTION
Inbox only includes direct replies and mentions, to summarize the most important notifications.
Activity monitors all the post where the user is tagged, sometimes "hell threads".

<img width="868" alt="inbox" src="https://user-images.githubusercontent.com/89577423/222843048-ffb276ec-f355-433e-a7ab-d930f38b4ef2.png">

<img width="868" alt="activity" src="https://user-images.githubusercontent.com/89577423/222843073-b0725642-0c87-4f4c-9bc1-445e9b73f819.png">

