### PR TITLE
[Draft] Show delegator identity in feed for delegated events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "nostr-types"
 version = "0.4.0-unstable"
-source = "git+https://github.com/mikedilger/nostr-types#606b2b5175ff1f16c7146b6579760cd131d79f39"
+source = "git+https://github.com/mikedilger/nostr-types#f8ff99b5b7db345d5d5cb9fd88b68d6e093e864a"
 dependencies = [
  "aes",
  "base64 0.21.0",


### PR DESCRIPTION
Here are some sample screenshots, with an event with no delegation, and one with.
Note that the event pubkey is the same, yet the username/avatar displayed is different.

![deleg0303_2](https://user-images.githubusercontent.com/13562139/222851333-299675a0-e2a2-4d38-8fb5-d9c7525f93e8.png)

![deleg0303_1](https://user-images.githubusercontent.com/13562139/222851381-ba58f7b2-8e35-4dc6-8166-d1085cac09ff.png)
