### PR TITLE
Add a You > Notes shortcut

### DIFF
--- a/src/ui/you/mod.rs
+++ b/src/ui/you/mod.rs
@@ -1,5 +1,6 @@
 use super::{GossipUi, Page};
 use crate::comms::ToOverlordMessage;
+use crate::feed::FeedKind;
 use crate::globals::{Globals, GLOBALS};
 use crate::ui::widgets::CopyButton;
 use eframe::egui;
@@ -20,6 +21,18 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
             app.set_page(Page::YourKeys);
         }
         ui.separator();
+        if let Some(pubkeyhex) = GLOBALS.signer.public_key() {
+            if ui
+                .add(SelectableLabel::new(
+                    app.page == Page::Feed(FeedKind::Person(pubkeyhex.into())),
+                    "Notes »",
+                ))
+                .clicked()
+            {
+                app.set_page(Page::Feed(FeedKind::Person(pubkeyhex.into())));
+            }
+            ui.separator();
+        }
         if ui
             .add(SelectableLabel::new(
                 app.page == Page::YourMetadata,


### PR DESCRIPTION
Now to access their notes the user has to find their own post, click on the user dropdown and click on the action "View...". This is an easy shortcut, the fact that it leads to the Feeds area (instead of creating a new Page type) is incidental but useful, because the user will then probably interact with other feeds.
<img width="872" alt="image" src="https://user-images.githubusercontent.com/89577423/222924296-588be7e3-5f9d-42ad-a3e3-dc516fed85c0.png">
