### PR TITLE
Recompute feed as soon as feed-related events are ready

### DIFF
--- a/src/overlord/mod.rs
+++ b/src/overlord/mod.rs
@@ -172,6 +172,10 @@ impl Overlord {
                 crate::process::process_new_event(event, false, None, None).await?;
             }
             tracing::info!("Loaded {} feed related events from the database", count);
+
+            // As soon as we have the feed events loaded, we trigger a feed recompute
+            GLOBALS.feed.ready.store(true, Ordering::Relaxed);
+            GLOBALS.feed.recompute().await?;
         }
 
         // Load viewed events set into memory


### PR DESCRIPTION
Before:
- on startup, the main feed was loaded with a sort of stale state (2-3 days old messages)
- after almost exactly 7 seconds, the feed was updated with the latest events from the DB

This would happen even if recent feed events were already in the DB.

After:
- on startup, the main feed shows the latest events from the DB within 1-2s

Not sure exactly where the original 7s delay came from, but it was probably related to the 3.5s `DEFAULT_FEED_RECOMPUTE_INTERVAL_MS` and setting `Feed.last_computed` on initialization, even before any event was loaded.