### PR TITLE
Fix search focus after first page view

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -169,7 +169,7 @@ struct GossipUi {
     import_pub: String,
     new_relay_url: String,
     search: String,
-    search_page: bool,
+    entering_search_page: bool,
 }
 
 impl Drop for GossipUi {
@@ -300,7 +300,7 @@ impl GossipUi {
             import_pub: "".to_owned(),
             new_relay_url: "".to_owned(),
             search: "".to_owned(),
-            search_page: false,
+            entering_search_page: false,
         }
     }
 
@@ -340,6 +340,9 @@ impl GossipUi {
             }
             Page::Feed(FeedKind::Person(pubkey)) => {
                 GLOBALS.feed.set_feed_to_person(pubkey.to_owned());
+            }
+            Page::Search => {
+                self.entering_search_page = true;
             }
             _ => {}
         }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -20,9 +20,9 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut Frame, ui: 
                 .desired_width(600.0),
         );
 
-        if !app.search_page {
+        if app.entering_search_page {
             response.request_focus();
-            app.search_page = true;
+            app.entering_search_page = false;
         }
 
         if ui.add(Button::new("Search")).clicked() {


### PR DESCRIPTION
On PR #288 I introduced a stupid bug: the field is focused only the first time the page is viewed.
This fixes it, but I don't know if it is conceptually correct and set_inner_place is the right place.
I also renamed the variable to make clear his use and because this would be a bit a non-sense writing:

```rust
Page::Search => {
    self.search_page = false;
}
```