### PR TITLE
Show image / video placeholders instead of full urls

### DIFF
--- a/src/ui/feed/note/content.rs
+++ b/src/ui/feed/note/content.rs
@@ -18,7 +18,21 @@ pub(super) fn render_content(
 
     for span in LinkFinder::new().kinds(&[LinkKind::Url]).spans(content) {
         if span.kind().is_some() {
-            crate::ui::widgets::break_anywhere_hyperlink_to(ui, span.as_str(), span.as_str());
+
+            if span.as_str().ends_with(".jpg")
+                || span.as_str().ends_with(".jpeg")
+                || span.as_str().ends_with(".png")
+                || span.as_str().ends_with(".gif")
+            {   
+                crate::ui::widgets::break_anywhere_hyperlink_to(ui, "[ Image ]", span.as_str());
+            } else if span.as_str().ends_with(".mov")
+                || span.as_str().ends_with(".mp4")
+            {   
+                crate::ui::widgets::break_anywhere_hyperlink_to(ui, "[ Video ]", span.as_str());
+            } else {
+                crate::ui::widgets::break_anywhere_hyperlink_to(ui, span.as_str(), span.as_str());
+            }
+
         } else {
             let s = span.as_str();
             let mut pos = 0;


### PR DESCRIPTION
While waiting for a correct management of images/videos it is probably useful to show a text placeholder instead of the complete url. Rationale: The image/video URL is rarely informative, often just confusing, with a standard placeholder when the user scans the content it can more easily identify external resources that are usually interesting information items. Hovering the placeholder provides the original URL, so the user can check it before clicking.

This could be useful even when there will be an option to show the images inline; if this option is off the user can click the placeholder to popup the image inside the main window.

Example:

<img width="868" alt="Screenshot 2023-03-12 alle 01 41 50" src="https://user-images.githubusercontent.com/89577423/224518091-24725294-9d3d-4ed4-bc15-285f190472ff.png">

