### PR TITLE
Improvements to Delegation handling

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -6,6 +6,7 @@ pub enum ToOverlordMessage {
     AddRelay(RelayUrl),
     AdvertiseRelayList,
     ChangePassphrase(String, String),
+    DelegationReset,
     DeletePub,
     DeletePriv,
     DropRelay(RelayUrl),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -289,7 +289,7 @@ impl GossipUi {
             replying_to: None,
             editing_metadata: false,
             metadata: Metadata::new(),
-            delegatee_tag_str: GLOBALS.delegation.get_delegatee_tag_as_str(),
+            delegatee_tag_str: "".to_owned(),
             nprofile_follow: "".to_owned(),
             nip05follow: "".to_owned(),
             follow_pubkey: "".to_owned(),

--- a/src/ui/you/delegation.rs
+++ b/src/ui/you/delegation.rs
@@ -7,59 +7,84 @@ use tokio::task;
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     ui.heading("Delegatee");
+    ui.label("If NIP-26 Delegation is set, I will post on behalf of the delegator");
     ui.add_space(24.0);
 
-    ui.label("Enter NIP-26 delegation tag, to post on the behalf of another indentity (I will be the delegatee)");
+    match GLOBALS.delegation.get_delegatee_tag() {
+        None => {
+            ui.label("No delegation is set");
+        }
+        Some(_dtag) => {
+            ui.label("Delegation is set!");
+            ui.horizontal(|ui| {
+                ui.label("Delegator pubkey:");
+                let delegator_npub = GLOBALS
+                    .delegation
+                    .get_delegator_pubkey_as_bech32_str()
+                    .unwrap_or("(not set)".to_string());
+                ui.label(&delegator_npub);
+                if ui
+                    .add(CopyButton {})
+                    .on_hover_text("Copy Public Key")
+                    .clicked()
+                {
+                    ui.output_mut(|o| o.copied_text = delegator_npub);
+                }
+            });
+            ui.label("Delegation tag:");
+            let mut dtag_str = GLOBALS.delegation.get_delegatee_tag_as_str();
+            ui.add_enabled(
+                false,
+                text_edit_multiline!(app, dtag_str)
+                    .interactive(false)
+                    .desired_width(f32::INFINITY),
+            );
+            ui.horizontal(|ui| {
+                if ui.button("Remove").clicked() {
+                    app.delegatee_tag_str = String::new();
+                    let _ = GLOBALS
+                        .to_overlord
+                        .send(crate::comms::ToOverlordMessage::DelegationReset);
+                }
+            });
+        }
+    };
+    ui.separator();
+    ui.add_space(12.0);
+
+    ui.label("Enter new delegation tag");
     ui.add(
         text_edit_multiline!(app, app.delegatee_tag_str)
             .hint_text("full delegation tag, JSON")
             .desired_width(f32::INFINITY),
     );
     ui.horizontal(|ui| {
-        ui.label("Delegator pubkey:");
-        let delegator_npub = GLOBALS
-            .delegation
-            .get_delegator_pubkey_as_bech32_str()
-            .unwrap_or("(not set)".to_string());
-        ui.label(&delegator_npub);
-        if ui
-            .add(CopyButton {})
-            .on_hover_text("Copy Public Key")
-            .clicked()
-        {
-            ui.output_mut(|o| o.copied_text = delegator_npub);
-        }
-    });
-    ui.horizontal(|ui| {
         if ui.button("Set").clicked() {
-            match GLOBALS.delegation.set(&app.delegatee_tag_str) {
-                Err(e) => {
-                    *GLOBALS.status_message.blocking_write() = format!("Could not parse tag {e}")
-                }
-                Ok(_) => {
-                    // normalize string
-                    app.delegatee_tag_str = GLOBALS.delegation.get_delegatee_tag_as_str();
-                    // save and statusmsg
-                    task::spawn(async move {
-                        if let Err(e) = GLOBALS.delegation.save_through_settings().await {
-                            tracing::error!("{}", e);
-                        }
-                        *GLOBALS.status_message.write().await = format!(
-                            "Delegation tag set, delegator: {}",
-                            GLOBALS
-                                .delegation
-                                .get_delegator_pubkey_as_bech32_str()
-                                .unwrap_or("?".to_string())
-                        );
-                    });
-                }
-            };
-        }
-        if ui.button("Remove").clicked() {
-            app.delegatee_tag_str = String::new();
-            let _ = GLOBALS
-                .to_overlord
-                .send(crate::comms::ToOverlordMessage::DelegationReset);
+            if !app.delegatee_tag_str.is_empty() {
+                match GLOBALS.delegation.set(&app.delegatee_tag_str) {
+                    Err(e) => {
+                        *GLOBALS.status_message.blocking_write() =
+                            format!("Could not parse tag {e}")
+                    }
+                    Ok(_) => {
+                        // reset entry field
+                        app.delegatee_tag_str = "".to_owned();
+                        // save and statusmsg
+                        task::spawn(async move {
+                            if let Err(e) = GLOBALS.delegation.save_through_settings().await {
+                                tracing::error!("{}", e);
+                            }
+                            *GLOBALS.status_message.write().await = format!(
+                                "Delegation tag set, delegator: {}",
+                                GLOBALS
+                                    .delegation
+                                    .get_delegator_pubkey_as_bech32_str()
+                                    .unwrap_or("?".to_string())
+                            );
+                        });
+                    }
+                };
+            }
         }
     });
     ui.separator();

--- a/src/ui/you/delegation.rs
+++ b/src/ui/you/delegation.rs
@@ -57,15 +57,9 @@ pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Fr
         }
         if ui.button("Remove").clicked() {
             app.delegatee_tag_str = String::new();
-            if GLOBALS.delegation.reset() {
-                // save and statusmsg
-                task::spawn(async move {
-                    if let Err(e) = GLOBALS.delegation.save_through_settings().await {
-                        tracing::error!("{}", e);
-                    }
-                    *GLOBALS.status_message.write().await = "Delegation tag removed".to_string();
-                });
-            }
+            let _ = GLOBALS
+                .to_overlord
+                .send(crate::comms::ToOverlordMessage::DelegationReset);
         }
     });
     ui.separator();


### PR DESCRIPTION
Improvements to Delegation handling, see https://github.com/catenocrypt/gossip/issues/1

- Delete delegation too when identity is deleted, to prevent accidental preserving of wrong delegation
- Improved entry for delegation, separate showing of current and input of new