### PR TITLE
Implement nip 27

### DIFF
--- a/src/ui/feed/note/content.rs
+++ b/src/ui/feed/note/content.rs
@@ -15,6 +15,7 @@ pub(super) fn render_content(
     content: &str,
 ) -> Option<NoteData> {
     let tag_re = app.tag_re.clone();
+    let nip27_re = app.nip27_re.clone();
     ui.style_mut().spacing.item_spacing.x = 0.0;
 
     // Optional repost return
@@ -95,9 +96,8 @@ pub(super) fn render_content(
             let rest = &s[pos..];
             // implement NIP-27 nostr: links that include NIP-19 bech32 references
             if rest.contains("nostr:") {
-                let regx = regex::Regex::new(r"(?i:nostr:[[:alnum:]]+)").unwrap();
                 let mut nospos = 0;
-                for mat in regx.find_iter(rest) {
+                for mat in nip27_re.find_iter(rest) {
                     ui.label(&s[nospos..mat.start()]); // print whatever comes before the match
                     let mut link_parsed = false;
                     let link = &s[mat.start() + 6..mat.end()];

--- a/src/ui/feed/note/content.rs
+++ b/src/ui/feed/note/content.rs
@@ -73,10 +73,6 @@ pub(super) fn render_content(
                                 }
                             }
                             if render_link {
-                                // insert a newline if the current line has text
-                                if ui.cursor().min.x > ui.max_rect().min.y {
-                                    ui.end_row();
-                                }
                                 render_event_link(app, ui, note, id);
                             }
                         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -135,6 +135,7 @@ struct GossipUi {
     settings: Settings,
     avatars: HashMap<PublicKeyHex, TextureHandle>,
     tag_re: regex::Regex,
+    nip27_re: regex::Regex,
 
     // Search result
     search_result: String,
@@ -279,6 +280,7 @@ impl GossipUi {
             settings,
             avatars: HashMap::new(),
             tag_re: regex::Regex::new(r"(\#\[\d+\])").unwrap(),
+            nip27_re: regex::Regex::new(r"(?i:nostr:[[:alnum:]]+)").unwrap(),
             search_result: "".to_owned(),
             draft: "".to_owned(),
             tag_someone: "".to_owned(),


### PR DESCRIPTION
NIP-27 was merged a couple of days ago and specifies mentions and silent mentions using the `nostr:<NIP-19>` link type. Clients are starting to roll this out (Snort already has) so it makes sense to support at least "npub1", "nevent1" and "note1" for now.

Test note: note1a0g3ysxtnhszmraxcwlezzf9aaa9cfalj3r2g0nx97a9h7pj47zqr8s04m