### PR TITLE
Add setting to follow OS dark-mode setting

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_OFFLINE: bool = false;
 pub const DEFAULT_THEME: Theme = Theme {
     variant: ThemeVariant::Default,
     dark_mode: false,
-    follow_os_dark_mode: true,
+    follow_os_dark_mode: false,
 };
 pub const DEFAULT_SET_CLIENT_TAG: bool = false;
 pub const DEFAULT_SET_USER_AGENT: bool = false;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_OFFLINE: bool = false;
 pub const DEFAULT_THEME: Theme = Theme {
     variant: ThemeVariant::Default,
     dark_mode: false,
+    follow_os_dark_mode: true,
 };
 pub const DEFAULT_SET_CLIENT_TAG: bool = false;
 pub const DEFAULT_SET_USER_AGENT: bool = false;
@@ -153,6 +154,7 @@ impl Settings {
                 "pow" => settings.pow = row.1.parse::<u8>().unwrap_or(DEFAULT_POW),
                 "offline" => settings.offline = numstr_to_bool(row.1),
                 "dark_mode" => settings.theme.dark_mode = numstr_to_bool(row.1),
+                "follow_os_dark_mode" => settings.theme.follow_os_dark_mode = numstr_to_bool(row.1),
                 "theme" => {
                     for theme_variant in ThemeVariant::all() {
                         if &*row.1 == theme_variant.name() {
@@ -221,6 +223,7 @@ impl Settings {
              ('pow', ?),\
              ('offline', ?),\
              ('dark_mode', ?),\
+             ('follow_os_dark_mode', ?),\
              ('theme', ?),\
              ('set_client_tag', ?),\
              ('set_user_agent', ?),\
@@ -250,6 +253,7 @@ impl Settings {
             self.pow,
             bool_to_numstr(self.offline),
             bool_to_numstr(self.theme.dark_mode),
+            bool_to_numstr(self.theme.follow_os_dark_mode),
             self.theme.variant.name(),
             bool_to_numstr(self.set_client_tag),
             bool_to_numstr(self.set_user_agent),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -461,6 +461,21 @@ impl eframe::App for GossipUi {
             }
         }
 
+        {
+            // detect if the OS has changed dark/light mode
+            let os_dark_mode = ctx.style().visuals.dark_mode;
+            if os_dark_mode != self.settings.theme.dark_mode {
+                if self.settings.theme.follow_os_dark_mode {
+                    // switch to the OS setting
+                    self.settings.theme.dark_mode = os_dark_mode;
+                    theme::apply_theme(self.settings.theme, ctx);
+                } else {
+                    // re-apply our setting overriding OS
+                    theme::apply_theme(self.settings.theme, ctx);
+                }
+            }
+        }
+
         egui::TopBottomPanel::top("menu").show(ctx, |ui| {
             ui.add_space(6.0);
             ui.horizontal(|ui| {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -63,6 +63,7 @@ pub fn run() -> Result<(), Error> {
         resizable: true,
         centered: true,
         vsync: true,
+        follow_system_theme: GLOBALS.settings.read().theme.follow_os_dark_mode,
         ..Default::default()
     };
 
@@ -464,18 +465,13 @@ impl eframe::App for GossipUi {
             }
         }
 
-        {
+        if self.settings.theme.follow_os_dark_mode {
             // detect if the OS has changed dark/light mode
             let os_dark_mode = ctx.style().visuals.dark_mode;
             if os_dark_mode != self.settings.theme.dark_mode {
-                if self.settings.theme.follow_os_dark_mode {
-                    // switch to the OS setting
-                    self.settings.theme.dark_mode = os_dark_mode;
-                    theme::apply_theme(self.settings.theme, ctx);
-                } else {
-                    // re-apply our setting overriding OS
-                    theme::apply_theme(self.settings.theme, ctx);
-                }
+                // switch to the OS setting
+                self.settings.theme.dark_mode = os_dark_mode;
+                theme::apply_theme(self.settings.theme, ctx);
             }
         }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -200,7 +200,7 @@ impl Drop for GossipUi {
 
 impl GossipUi {
     fn new(cctx: &eframe::CreationContext<'_>) -> Self {
-        let settings = GLOBALS.settings.read().clone();
+        let mut settings = GLOBALS.settings.read().clone();
 
         if let Some(dpi) = settings.override_dpi {
             let ppt: f32 = dpi as f32 / 72.0;
@@ -282,6 +282,9 @@ impl GossipUi {
         };
 
         // Apply current theme
+        if settings.theme.follow_os_dark_mode {
+            settings.theme.dark_mode = cctx.egui_ctx.style().visuals.dark_mode;
+        }
         theme::apply_theme(settings.theme, &cctx.egui_ctx);
 
         GossipUi {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -212,23 +212,25 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
 
                     ui.horizontal(|ui| {
                         ui.label("Theme:");
-                        if app.settings.theme.dark_mode {
-                            if ui
-                                .add(Button::new("🌙 Dark"))
-                                .on_hover_text("Switch to light mode")
-                                .clicked()
-                            {
-                                app.settings.theme.dark_mode = false;
-                                super::theme::apply_theme(app.settings.theme, ctx);
-                            }
-                        } else {
-                            if ui
-                                .add(Button::new("☀ Light"))
-                                .on_hover_text("Switch to dark mode")
-                                .clicked()
-                            {
-                                app.settings.theme.dark_mode = true;
-                                super::theme::apply_theme(app.settings.theme, ctx);
+                        if !app.settings.theme.follow_os_dark_mode {
+                            if app.settings.theme.dark_mode {
+                                if ui
+                                    .add(Button::new("🌙 Dark"))
+                                    .on_hover_text("Switch to light mode")
+                                    .clicked()
+                                {
+                                    app.settings.theme.dark_mode = false;
+                                    super::theme::apply_theme(app.settings.theme, ctx);
+                                }
+                            } else {
+                                if ui
+                                    .add(Button::new("☀ Light"))
+                                    .on_hover_text("Switch to dark mode")
+                                    .clicked()
+                                {
+                                    app.settings.theme.dark_mode = true;
+                                    super::theme::apply_theme(app.settings.theme, ctx);
+                                }
                             }
                         }
                         let theme_combo = egui::ComboBox::from_id_source("Theme");
@@ -242,10 +244,8 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                                     };
                                 }
                             });
-                        ui.checkbox(
-                            &mut app.settings.theme.follow_os_dark_mode,
-                            "Follow OS dark-mode"
-                        ).on_hover_text("Follow the operating system setting for dark-mode");
+                        ui.checkbox(&mut app.settings.theme.follow_os_dark_mode,"Follow OS dark-mode")
+                            .on_hover_text("Follow the operating system setting for dark-mode (requires app-restart to take effect)");
                     });
 
                     ui.add_space(12.0);

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -211,6 +211,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                     ui.add_space(12.0);
 
                     ui.horizontal(|ui| {
+                        ui.label("Theme:");
                         if app.settings.theme.dark_mode {
                             if ui
                                 .add(Button::new("🌙 Dark"))
@@ -230,7 +231,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                                 super::theme::apply_theme(app.settings.theme, ctx);
                             }
                         }
-                        let theme_combo = egui::ComboBox::from_label("Theme");
+                        let theme_combo = egui::ComboBox::from_id_source("Theme");
                         theme_combo
                             .selected_text( app.settings.theme.name() )
                             .show_ui(ui, |ui| {
@@ -241,6 +242,10 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                                     };
                                 }
                             });
+                        ui.checkbox(
+                            &mut app.settings.theme.follow_os_dark_mode,
+                            "Follow OS dark-mode"
+                        ).on_hover_text("Follow the operating system setting for dark-mode");
                     });
 
                     ui.add_space(12.0);

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -37,6 +37,7 @@ pub enum ThemeVariant {
 pub struct Theme {
     pub variant: ThemeVariant,
     pub dark_mode: bool,
+    pub follow_os_dark_mode: bool,
 }
 pub struct FeedProperties {
     /// This is a thread


### PR DESCRIPTION
egui already automatically follows the OS dark-mode setting, but we don't handle it with our theme selection, resulting in messed up visuals. Now we check for this case and let the user decide whether to follow the OS or not.