### PR TITLE
Quick fix for ffmpeg cpu hog

### DIFF
--- a/src/ui/feed/note/content.rs
+++ b/src/ui/feed/note/content.rs
@@ -445,6 +445,9 @@ fn try_render_video(app: &mut GossipUi, ui: &mut Ui, url: Url) -> Option<Respons
             }
 
             // show the player
+            if !show_full_width {
+                player.stop();
+            }
             let response = player.ui( ui, [ size.x, size.y ] );
 
             // TODO fix click action


### PR DESCRIPTION
The player keeps its threads running when paused, the threads get destroyed on stop. We will default to stopping the video instead of pausing.