### PR TITLE
allow to customize path to the data dirs

### DIFF
--- a/src/about.rs
+++ b/src/about.rs
@@ -1,3 +1,5 @@
+use crate::profile::Profile;
+
 #[derive(Debug)]
 pub struct About {
     pub name: String,
@@ -11,13 +13,10 @@ pub struct About {
 }
 
 pub fn about() -> About {
-    let data_dir = match dirs::data_dir() {
-        Some(mut d) => {
-            d.push("gossip");
-            format!("{}/", d.display())
-        }
-        None => "Cannot find a directory to store application data.".to_owned(),
-    };
+    let data_dir = Profile::current()
+        .map_or(
+            "Cannot find a directory to store application data.".to_owned(),
+            |p| { format!("{}/", p.profile_dir.display()) });
 
     let mut version = env!("CARGO_PKG_VERSION").to_string();
     if version.contains("unstable") {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -32,17 +32,16 @@ use rusqlite::Connection;
 use std::fs;
 use std::sync::atomic::Ordering;
 use tokio::task;
+use crate::profile::Profile;
 
 pub fn init_database() -> Result<Connection, Error> {
-    let mut data_dir = dirs::data_dir()
-        .ok_or::<Error>("Cannot find a directory to store application data.".into())?;
-    data_dir.push("gossip");
+    let profile_dir = Profile::current()?.profile_dir;
 
     // Create our data directory only if it doesn't exist
-    fs::create_dir_all(&data_dir)?;
+    fs::create_dir_all(&profile_dir)?;
 
     // Connect to (or create) our database
-    let mut db_path = data_dir.clone();
+    let mut db_path = profile_dir;
     db_path.push("gossip.sqlite");
     let connection = Connection::open_with_flags(
         &db_path,

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::RwLock;
 use tokio::task;
+use crate::profile::Profile;
 
 #[derive(Debug, Default)]
 pub struct Fetcher {
@@ -55,15 +56,13 @@ impl Fetcher {
         };
 
         // Setup the cache directory
-        let mut cache_dir = match dirs::data_dir() {
-            Some(d) => d,
-            None => {
+        let cache_dir = match Profile::current() {
+            Ok(p) => p.cache_dir,
+            Err(_) => {
                 f.dead = Some("No Data Directory.".to_owned());
                 return f;
             }
         };
-        cache_dir.push("gossip");
-        cache_dir.push("cache");
 
         // Create our data directory only if it doesn't exist
         if let Err(e) = fs::create_dir_all(&cache_dir) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ mod settings;
 mod signer;
 mod tags;
 mod ui;
+mod profile;
 
 use crate::comms::ToOverlordMessage;
 use crate::error::Error;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,94 @@
+use std::env;
+use std::path::{PathBuf};
+use std::sync::{RwLock};
+use crate::error::Error;
+
+type ProfileRef = Option<Profile>;
+
+lazy_static! {
+    static ref CURRENT: RwLock<ProfileRef> = RwLock::new(None);
+}
+
+///
+/// Access to current directories
+///
+#[derive(Clone, Debug, PartialEq)]
+pub struct Profile {
+    /// The base directory for all gossip data, may be the same as profile_dir if it's a default profile
+    pub base_dir: PathBuf,
+    /// The directory for current profile
+    pub profile_dir: PathBuf,
+    /// The directory for cache
+    pub cache_dir: PathBuf,
+}
+
+impl Profile {
+    fn new() -> Result<Profile, Error> {
+
+        // By default it's what `dirs::data_dir()` gives, but we allow overriding the base directory via env vars
+        let base_dir = match env::var("GOSSIP_DIR") {
+            Ok(dir) => {
+                tracing::info!("Using GOSSIP_DIR: {}", dir);
+                PathBuf::from(dir)
+            },
+            Err(_) => {
+                let mut base_dir = dirs::data_dir()
+                    .ok_or::<Error>("Cannot find a directory to store application data.".into())?;
+                base_dir.push("gossip");
+                base_dir
+            }
+        };
+
+        // optional profile name, if specified the the user data is stored in a subdirectory
+        let profile_dir = match env::var("GOSSIP_PROFILE") {
+            Ok(profile) => {
+                if "cache".eq_ignore_ascii_case(profile.as_str()) {
+                    return Err(Error::from("Profile name 'cache' is reserved."));
+                }
+
+                let mut dir = base_dir.clone();
+                dir.push(profile);
+
+                {
+                    // make sure the profile dir is inside the base dir, i.e. protect from directory traversal
+                    let base_canonical = base_dir.canonicalize()
+                        .map_err(|_| Error::from("Base dir is invalid."))?;
+                    let profile_canonical = dir.canonicalize()
+                        .map_err(|_| Error::from("Profile dir is invalid."))?;
+                    if !profile_canonical.starts_with(&base_canonical) {
+                        return Err(Error::from(format!("Profile dir is outside of the base dir ({:?} not in {:?})", profile_canonical, base_canonical)));
+                    }
+                }
+
+                dir
+            }
+            Err(_) => base_dir.clone()
+        };
+
+        let cache_dir = {
+            let mut base_dir = base_dir.clone();
+            base_dir.push("cache");
+            base_dir
+        };
+
+        Ok(Profile {
+            base_dir,
+            profile_dir,
+            cache_dir,
+        })
+    }
+
+    pub fn current() -> Result<Profile, Error> {
+        {
+            // create a new scope to drop the read lock before we try to create a new profile if it doesn't exist
+            let current = CURRENT.read().unwrap();
+            if current.is_some() {
+                return Ok(current.as_ref().unwrap().clone())
+            }
+        }
+        let created = Profile::new()?;
+        let mut w = CURRENT.write().unwrap();
+        *w = Some(created.clone());
+        Ok(created)
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -3,10 +3,8 @@ use std::path::{PathBuf};
 use std::sync::{RwLock};
 use crate::error::Error;
 
-type ProfileRef = Option<Profile>;
-
 lazy_static! {
-    static ref CURRENT: RwLock<ProfileRef> = RwLock::new(None);
+    static ref CURRENT: RwLock<Option<Profile>> = RwLock::new(None);
 }
 
 ///


### PR DESCRIPTION
rel #377 

PR allows to specify _data dir_ as `GOSSIP_DIR` env variable. And, optionally, specify a profile which turns into a subdir with `GOSSIP_PROFILE`.

The only different to the original request in #377 that by default profile is not stored in the `default` subdir, because that would break the current installations. 