### PR TITLE
Add personal pubkey to metadata refresh list as well (important for b…

### DIFF
--- a/src/overlord/mod.rs
+++ b/src/overlord/mod.rs
@@ -1311,7 +1311,12 @@ impl Overlord {
 
     // This gets it whether we had it or not. Because it might have changed.
     async fn refresh_followed_metadata(&mut self) -> Result<(), Error> {
-        let pubkeys = GLOBALS.people.get_followed_pubkeys();
+        let mut pubkeys = GLOBALS.people.get_followed_pubkeys();
+
+        // add own pubkey as well
+        if let Some(pubkey) = GLOBALS.signer.public_key() {
+            pubkeys.push(pubkey.into())
+        }
 
         let num_relays_per_person = GLOBALS.settings.read().num_relays_per_person;
 


### PR DESCRIPTION
When trying to bootstrap an empty gossip data run with fiatjaf's pubkey, I could not get it to load his profile. Only when I added this line and set damus.io and purplepag.es to "WRITE" and "ADVERTISE" did "Fetch Metadata" populate his following list. 

We should create an import wizard that asks for 2 profile relays and then configure them for the user to make onboarding "just work".