### PR TITLE
allow to copy a profile npub

### DIFF
--- a/src/ui/people/person.rs
+++ b/src/ui/people/person.rs
@@ -76,6 +76,9 @@ fn content(
         ui.horizontal_wrapped(|ui| {
             ui.label(RichText::new("Public Key: ").strong());
             ui.label(&npub);
+            if ui.add(CopyButton {}).on_hover_text("Copy Public Key").clicked() {
+                ui.output_mut(|o| o.copied_text = npub.to_owned());
+            }
             if ui.button("⚃").on_hover_text("Show as QR code").clicked() {
                 app.qr_codes.remove("person_qr");
                 app.person_qr = Some("npub");


### PR DESCRIPTION
Found out there is no way to copy npub of a profile into the clipboard b/c the text is not selectable and no copy button present. I've added a copy button.