### PR TITLE
Keep only the first 10 output lines when unable to parse NIP-11

### DIFF
--- a/src/overlord/minion/mod.rs
+++ b/src/overlord/minion/mod.rs
@@ -123,10 +123,14 @@ impl Minion {
                             }
                             Err(e) => {
                                 tracing::warn!(
-                                    "{}: Unable to parse response as NIP-11 ({}): {}",
+                                    "{}: Unable to parse response as NIP-11 ({}): {}\n",
                                     &self.url,
                                     e,
                                     text
+                                    .lines()
+                                    .take(10)
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
                                 );
                             }
                         }


### PR DESCRIPTION
Quick fix to make the logs more readable.

Fixes #434 