### PR TITLE
nip36: autoapprove setting option

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -37,6 +37,7 @@ pub struct Settings {
     pub reactions: bool,
     pub enable_zap_receipts: bool,
     pub show_media: bool,
+    pub approve_content_warning: bool,
 
     // Posting Settings
     pub pow: u8,
@@ -120,6 +121,7 @@ impl Default for Settings {
             reactions: true,
             enable_zap_receipts: true,
             show_media: true,
+            approve_content_warning: false,
 
             // Posting settings
             pow: 0,

--- a/src/storage/import/mod.rs
+++ b/src/storage/import/mod.rs
@@ -235,6 +235,7 @@ where
             "highlight_unread_events" => settings.highlight_unread_events = numstr_to_bool(value),
             "posting_area_at_top" => settings.posting_area_at_top = numstr_to_bool(value),
             "enable_zap_receipts" => settings.enable_zap_receipts = numstr_to_bool(value),
+            "approve_content_warning" => settings.approve_content_warning = numstr_to_bool(value),
             _ => {}
         }
     }

--- a/src/storage/migrations/settings/settings1.rs
+++ b/src/storage/migrations/settings/settings1.rs
@@ -34,6 +34,7 @@ pub struct Settings1 {
     pub highlight_unread_events: bool,
     pub posting_area_at_top: bool,
     pub enable_zap_receipts: bool,
+    pub approve_content_warning: bool,
 }
 
 impl Default for Settings1 {
@@ -72,6 +73,7 @@ impl Default for Settings1 {
             highlight_unread_events: true,
             posting_area_at_top: true,
             enable_zap_receipts: true,
+            approve_content_warning: false,
         }
     }
 }

--- a/src/storage/migrations/settings/settings2.rs
+++ b/src/storage/migrations/settings/settings2.rs
@@ -38,6 +38,7 @@ pub struct Settings2 {
     pub reactions: bool,
     pub enable_zap_receipts: bool,
     pub show_media: bool,
+    pub approve_content_warning: bool,
 
     // Posting Settings
     pub pow: u8,
@@ -121,6 +122,7 @@ impl Default for Settings2 {
             reactions: true,
             enable_zap_receipts: true,
             show_media: true,
+            approve_content_warning: false,
 
             // Posting settings
             pow: 0,
@@ -207,6 +209,7 @@ impl From<Settings1> for Settings2 {
             reactions: old.reactions,
             enable_zap_receipts: old.enable_zap_receipts,
             show_media: old.show_media,
+            approve_content_warning: old.approve_content_warning,
 
             // Posting settings
             pow: old.pow,

--- a/src/ui/feed/note/mod.rs
+++ b/src/ui/feed/note/mod.rs
@@ -914,7 +914,8 @@ fn render_content(
                             .monospace()
                             .italics(),
                         );
-                        if ui.button("Show Post").clicked() || app.settings.approve_content_warning {
+                        if ui.button("Show Post").clicked() || app.settings.approve_content_warning
+                        {
                             app.approved.insert(event.id);
                             app.height.remove(&event.id); // will need to be recalculated.
                         }

--- a/src/ui/feed/note/mod.rs
+++ b/src/ui/feed/note/mod.rs
@@ -914,7 +914,7 @@ fn render_content(
                             .monospace()
                             .italics(),
                         );
-                        if ui.button("Show Post").clicked() {
+                        if ui.button("Show Post").clicked() || app.settings.approve_content_warning {
                             app.approved.insert(event.id);
                             app.height.remove(&event.id); // will need to be recalculated.
                         }

--- a/src/ui/settings/content.rs
+++ b/src/ui/settings/content.rs
@@ -78,6 +78,14 @@ pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Fr
         .on_hover_text(
             "If off, you have to click to (potentially fetch and) render media inline. If on, all media referenced by posts in your feed will be (potentially fetched and) rendered. However, if Fetch Media is disabled, only cached media can be shown as media will not be fetched."
         );
+
+    ui.checkbox(
+        &mut app.settings.approve_content_warning,
+        "Approve all content-warning tagged media automatically",
+    )
+        .on_hover_text(
+            "If off, you have to click to show content-warning tagged media. If on, all content-warning tagged media in your feed will be rendered."
+        );
 }
 
 fn secs_to_string(secs: u64) -> String {


### PR DESCRIPTION
As described in #464,  a user may want a setting option to allow automatically content-warning tagged media.

This Pull Request adds a new option in [Settings -> Content -> Event Content Settings] to allow approval of all content-warning media.

![gossip_approval_settings](https://github.com/mikedilger/gossip/assets/52411515/e5939299-2661-483f-90e9-71dd6fb33f40)

