### PR TITLE
Refactor cache folders

### DIFF
--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -271,14 +271,14 @@ impl Fetcher {
             return;
         }
 
-        let avatar_file = GLOBALS.fetcher.cache_file(CacheType::Avatar, &url);
+        let _avatar_file = GLOBALS.fetcher.cache_file(CacheType::Avatar, &url);
         let etag_file = GLOBALS.fetcher.cache_file(CacheType::Etag, &url);
         let cache_file = GLOBALS.fetcher.cache_file(CacheType::Content, &url);
 
         let etag: Option<Vec<u8>> = match tokio::fs::read(etag_file.as_path()).await {
             Ok(contents) => {
                 // etag is only valid if the contents file is present
-                if matches!(tokio::fs::try_exists(cache_file.as_path()).await, Ok(true)) {
+                if matches!(tokio::fs::try_exists(etag_file.as_path()).await, Ok(true)) {
                     Some(contents)
                 } else {
                     None
@@ -530,7 +530,7 @@ impl Fetcher {
                 cache_file.push(hash);
                 cache_file
             }
-            CacheType::Etag => {
+            CacheType::Etag => { // etag is in the same folder as avatars
                 let mut avatar_file = self.avatars_dir.read().unwrap().clone();
                 avatar_file.push(hash);
                 avatar_file.with_extension("etag")

--- a/src/media.rs
+++ b/src/media.rs
@@ -121,7 +121,7 @@ impl Media {
             return None; // can recover if the setting is switched
         }
 
-        match GLOBALS.fetcher.try_get(
+        match GLOBALS.fetcher.try_get(crate::fetcher::CacheType::Content, 
             url,
             Duration::from_secs(60 * 60 * GLOBALS.storage.read_setting_media_becomes_stale_hours()),
         ) {

--- a/src/people.rs
+++ b/src/people.rs
@@ -447,7 +447,7 @@ impl People {
 
         // If it failed before, error out now
         if GLOBALS.failed_avatars.blocking_read().contains(pubkey) {
-            return None; // cannot recover.
+            return None; // cannot recover
         }
 
         // If it is pending processing, respond now
@@ -486,7 +486,7 @@ impl People {
             }
         };
 
-        match GLOBALS.fetcher.try_get(
+        match GLOBALS.fetcher.try_get(crate::fetcher::CacheType::Avatar,
             &url,
             Duration::from_secs(
                 60 * 60 * GLOBALS.storage.read_setting_avatar_becomes_stale_hours(),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -26,6 +26,9 @@ pub struct Profile {
 
     /// The LMDB directory (within the profile directory)
     pub lmdb_dir: PathBuf,
+
+    /// The directory for avatars (subfolder of cache)
+    pub avatars_dir: PathBuf,
 }
 
 impl Profile {
@@ -53,13 +56,20 @@ impl Profile {
             }
         };
 
+        // Cache folder structure
         let cache_dir = {
             let mut cache_dir = base_dir.clone();
-            cache_dir.push("cache");
+            cache_dir.push("cache/contents");
             cache_dir
         };
 
-        // optional profile name, if specified the the user data is stored in a subdirectory
+        let avatars_dir = {
+            let mut avatars_dir = base_dir.clone();
+            avatars_dir.push("cache/avatars");
+            avatars_dir
+        };
+
+        // Optional profile name, if specified the user data is stored in a subdirectory
         let profile_dir = match env::var("GOSSIP_PROFILE") {
             Ok(profile) => {
                 if "cache".eq_ignore_ascii_case(profile.as_str()) {
@@ -105,12 +115,14 @@ impl Profile {
         fs::create_dir_all(&cache_dir)?;
         fs::create_dir_all(&profile_dir)?;
         fs::create_dir_all(&lmdb_dir)?;
+        fs::create_dir_all(&avatars_dir)?;
 
         Ok(Profile {
             base_dir,
             profile_dir,
             cache_dir,
             lmdb_dir,
+            avatars_dir,
         })
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -938,17 +938,16 @@ impl GossipUi {
         GLOBALS.people.person_of_interest(person.pubkey);
 
         ui.horizontal_wrapped(|ui| {
-
             let name = match &person.petname {
                 // Highlight that this is our petname, not their chosen name
                 Some(pn) => {
                     let name = format!("☰ {}", pn);
                     RichText::new(name).italics().underline()
-                },
+                }
                 None => {
                     let name = format!("☰ {}", crate::names::display_name_from_person(person));
                     RichText::new(name)
-                },
+                }
             };
 
             ui.menu_button(name, |ui| {

--- a/src/ui/people/person.rs
+++ b/src/ui/people/person.rs
@@ -65,16 +65,12 @@ fn content(app: &mut GossipUi, ctx: &Context, ui: &mut Ui, pubkey: PublicKey, pe
                 ui.label("Pet name:");
                 if app.editing_petname {
                     let edit_color = app.settings.theme.input_text_color();
-                    ui.add(
-                        TextEdit::singleline(&mut app.petname)
-                            .text_color(edit_color)
-                    );
+                    ui.add(TextEdit::singleline(&mut app.petname).text_color(edit_color));
                     if ui.button("save").clicked() {
                         let mut person = person.clone();
                         person.petname = Some(app.petname.clone());
                         if let Err(e) = GLOBALS.storage.write_person(&person, None) {
-                            GLOBALS.status_queue.write()
-                                .write(format!("{}", e));
+                            GLOBALS.status_queue.write().write(format!("{}", e));
                         }
                         app.editing_petname = false;
                     }
@@ -85,8 +81,7 @@ fn content(app: &mut GossipUi, ctx: &Context, ui: &mut Ui, pubkey: PublicKey, pe
                         let mut person = person.clone();
                         person.petname = None;
                         if let Err(e) = GLOBALS.storage.write_person(&person, None) {
-                            GLOBALS.status_queue.write()
-                                .write(format!("{}", e));
+                            GLOBALS.status_queue.write().write(format!("{}", e));
                         }
                         app.editing_petname = false;
                     }
@@ -102,11 +97,10 @@ fn content(app: &mut GossipUi, ctx: &Context, ui: &mut Ui, pubkey: PublicKey, pe
                                 let mut person = person.clone();
                                 person.petname = None;
                                 if let Err(e) = GLOBALS.storage.write_person(&person, None) {
-                                    GLOBALS.status_queue.write()
-                                        .write(format!("{}", e));
+                                    GLOBALS.status_queue.write().write(format!("{}", e));
                                 }
                             }
-                        },
+                        }
                         None => {
                             ui.label(RichText::new("none").italics());
                             if ui.button("add").clicked() {


### PR DESCRIPTION
As describe in #480 one solution could be:

3. "Separate avatars and banners from other content, and only prune the other content."

This PR:
- structures cache folder in subfolder (for contents and avatars)
- introduces a CacheType enum

WIP (to be solved):
- avatar cache folder is not populated

Todo:
- Copy current files in ex `cache/` into `cache/contents/` ?