### PR TITLE
Limit njump nevents to 3 relay hints to have a shorter URL

### DIFF
--- a/src/ui/feed/note/mod.rs
+++ b/src/ui/feed/note/mod.rs
@@ -402,6 +402,7 @@ fn render_note_inner(
                                         Ok(vec) => vec
                                             .iter()
                                             .map(|(url, _)| url.to_unchecked_url())
+                                            .take(3) // Limit to 3 relay hints
                                             .collect(),
                                         Err(_) => vec![],
                                     },


### PR DESCRIPTION
As per subject.