### PR TITLE
Fix multiple windows on Wayland

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ base64 = "0.21"
 bech32 = "0.9"
 dashmap = "5.4"
 dirs = "5.0"
-eframe = { git = "https://github.com/mikedilger/egui", rev = "50393e4f34ac6246b8c2424e42fbe5b95e4b4452", features = [ "persistence" ] }
+eframe = { git = "https://github.com/mikedilger/egui", rev = "50393e4f34ac6246b8c2424e42fbe5b95e4b4452", features = [ "persistence", "wayland" ] }
 egui-winit = { git = "https://github.com/mikedilger/egui", rev = "50393e4f34ac6246b8c2424e42fbe5b95e4b4452", features = [ "default" ] }
 egui_extras = { git = "https://github.com/mikedilger/egui", rev = "50393e4f34ac6246b8c2424e42fbe5b95e4b4452", features = [ "image", "svg" ] }
 egui-video = { git = "https://github.com/mikedilger/egui-video", rev = "81cc3ee58818754272582397161cc55ff11bde18",  features = [ "from_bytes" ], optional = true }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -60,6 +60,8 @@ pub fn run() -> Result<(), Error> {
     let (icon_width, icon_height) = icon.dimensions();
 
     let options = eframe::NativeOptions {
+        #[cfg(target_os = "linux")]
+        app_id: Some("gossip".to_string()),
         decorated: true,
         #[cfg(target_os = "macos")]
         fullsize_content: true,


### PR DESCRIPTION
Enable Wayland feature for `eframe` and sets the `app_id` so that Wayland doesn't open a new window each time the user clicks on the desktop icon. First draft changes to address #527.