### PR TITLE
Uniform view's titles

### DIFF
--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -55,17 +55,17 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
         FeedKind::Followed(with_replies) => {
             let feed = GLOBALS.feed.get_followed();
             let id = if with_replies { "main" } else { "general" };
-
+            ui.add_space(10.0);
             ui.allocate_ui_with_layout(
                 Vec2::new(ui.available_width(), ui.spacing().interact_size.y),
                 egui::Layout::left_to_right(egui::Align::Center),
                 |ui| {
                     add_left_space(ui);
-                    ui.label("Main Feed");
+                    ui.heading("Main feed");
                     recompute_btn(app, ui);
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.add_space(16.0);
+                        ui.add_space(10.0);
                         ui.label(RichText::new("Include replies").size(11.0));
                         let size = ui.spacing().interact_size.y * egui::vec2(1.6, 0.8);
                         if crate::ui::components::switch_with_size(
@@ -89,7 +89,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
                     });
                 },
             );
-            ui.add_space(4.0);
+            ui.add_space(6.0);
             render_a_feed(app, ctx, frame, ui, feed, false, id);
         }
         FeedKind::Inbox(indirect) => {
@@ -104,17 +104,17 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
             }
             let feed = GLOBALS.feed.get_inbox();
             let id = if indirect { "activity" } else { "inbox" };
-
+            ui.add_space(10.0);
             ui.allocate_ui_with_layout(
                 Vec2::new(ui.available_width(), ui.spacing().interact_size.y),
                 egui::Layout::left_to_right(egui::Align::Center),
                 |ui| {
                     add_left_space(ui);
-                    ui.label("Inbox");
+                    ui.heading("Inbox");
                     recompute_btn(app, ui);
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.add_space(16.0);
+                        ui.add_space(10.0);
                         ui.label(RichText::new("Everything").size(11.0));
                         let size = ui.spacing().interact_size.y * egui::vec2(1.6, 0.8);
                         if crate::ui::components::switch_with_size(
@@ -136,23 +136,26 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
                     });
                 },
             );
-            ui.add_space(4.0);
+            ui.add_space(6.0);
             render_a_feed(app, ctx, frame, ui, feed, false, id);
         }
         FeedKind::Thread { id, .. } => {
-            ui.horizontal(|ui| {
-                ui.label("Thread");
-                recompute_btn(app, ui);
-            });
             if let Some(parent) = GLOBALS.feed.get_thread_parent() {
                 render_a_feed(app, ctx, frame, ui, vec![parent], true, &id.as_hex_string());
             }
         }
         FeedKind::Person(pubkey) => {
+            ui.add_space(10.0);
             ui.horizontal(|ui| {
-                ui.label(gossip_lib::names::tag_name_from_pubkey_lookup(&pubkey));
+                add_left_space(ui);
+                if Some(pubkey) == GLOBALS.signer.public_key() {
+                    ui.heading("My notes");
+                } else {
+                    ui.heading(gossip_lib::names::tag_name_from_pubkey_lookup(&pubkey));
+                }
                 recompute_btn(app, ui);
             });
+            ui.add_space(6.0);
 
             let feed = GLOBALS.feed.get_person_feed();
             render_a_feed(app, ctx, frame, ui, feed, false, &pubkey.as_hex_string());

--- a/gossip-bin/src/ui/help/mod.rs
+++ b/gossip-bin/src/ui/help/mod.rs
@@ -9,7 +9,7 @@ mod theme;
 
 pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     if app.page == Page::HelpHelp {
-        ui.add_space(24.0);
+        ui.add_space(10.0);
         ui.heading("Help - Getting Started");
         ui.add_space(12.0);
         ui.separator();

--- a/gossip-bin/src/ui/help/stats.rs
+++ b/gossip-bin/src/ui/help/stats.rs
@@ -6,7 +6,7 @@ use humansize::{format_size, DECIMAL};
 use std::sync::atomic::Ordering;
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
-    ui.add_space(24.0);
+    ui.add_space(10.0);
     ui.heading("Statistics".to_string());
     ui.add_space(12.0);
     ui.separator();

--- a/gossip-bin/src/ui/help/theme.rs
+++ b/gossip-bin/src/ui/help/theme.rs
@@ -15,7 +15,7 @@ enum Background {
 }
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
-    ui.add_space(24.0);
+    ui.add_space(10.0);
     ui.heading("Theme Test".to_string());
     ui.add_space(12.0);
     ui.separator();

--- a/gossip-bin/src/ui/people/follow.rs
+++ b/gossip-bin/src/ui/people/follow.rs
@@ -6,9 +6,12 @@ use gossip_lib::GLOBALS;
 use nostr_types::{Profile, PublicKey};
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
-    ui.add_space(30.0);
+    ui.add_space(10.0);
+    ui.horizontal_wrapped(|ui| {
+        ui.add_space(2.0);
+        ui.heading("Follow Someone");
+    });
 
-    ui.heading("Follow Someone");
     ui.add_space(10.0);
 
     ui.label(

--- a/gossip-bin/src/ui/relays/active.rs
+++ b/gossip-bin/src/ui/relays/active.rs
@@ -15,6 +15,7 @@ pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Fr
     ui.add_space(10.0);
     ui.horizontal_wrapped(|ui| {
         ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+            ui.add_space(2.0);
             ui.heading(Page::RelaysActivityMonitor.name());
             ui.set_enabled(!is_editing);
         });
@@ -83,3 +84,4 @@ fn get_relays(app: &mut GossipUi) -> Vec<Relay> {
     relays.sort_by(|a, b| super::sort_relay(&app.relays, a, b));
     relays
 }
+

--- a/gossip-bin/src/ui/relays/known.rs
+++ b/gossip-bin/src/ui/relays/known.rs
@@ -10,6 +10,7 @@ pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Fr
     let is_editing = app.relays.edit.is_some();
     ui.add_space(10.0);
     ui.horizontal_wrapped(|ui| {
+        ui.add_space(2.0);
         ui.heading(Page::RelaysKnownNetwork.name());
         ui.set_enabled(!is_editing);
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {

--- a/gossip-bin/src/ui/relays/mine.rs
+++ b/gossip-bin/src/ui/relays/mine.rs
@@ -11,6 +11,7 @@ pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Fr
     let is_editing = app.relays.edit.is_some();
     ui.add_space(10.0);
     ui.horizontal_wrapped(|ui| {
+        ui.add_space(2.0);
         ui.heading(Page::RelaysMine.name());
         ui.set_enabled(!is_editing);
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {

--- a/gossip-bin/src/ui/search.rs
+++ b/gossip-bin/src/ui/search.rs
@@ -9,6 +9,7 @@ use gossip_lib::GLOBALS;
 use std::sync::atomic::Ordering;
 
 pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut Frame, ui: &mut Ui) {
+    ui.add_space(10.0);
     ui.heading("Search notes and users");
 
     ui.add_space(12.0);

--- a/gossip-bin/src/ui/settings/mod.rs
+++ b/gossip-bin/src/ui/settings/mod.rs
@@ -11,6 +11,7 @@ mod posting;
 mod ui;
 
 pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Frame, ui: &mut Ui) {
+    ui.add_space(10.0);
     ui.heading("Settings");
 
     ui.with_layout(Layout::right_to_left(Align::Min), |ui| {

--- a/gossip-bin/src/ui/you/delegation.rs
+++ b/gossip-bin/src/ui/you/delegation.rs
@@ -6,7 +6,12 @@ use gossip_lib::GLOBALS;
 use tokio::task;
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
-    ui.heading("Delegatee");
+    ui.add_space(10.0);
+    ui.horizontal_wrapped(|ui| {
+        // ui.add_space(2.0);
+        ui.heading("Delegatee");
+    });
+    ui.add_space(10.0);
     ui.label("If NIP-26 Delegation is set, I will post on behalf of the delegator");
     ui.add_space(24.0);
 

--- a/gossip-bin/src/ui/you/metadata.rs
+++ b/gossip-bin/src/ui/you/metadata.rs
@@ -14,8 +14,12 @@ lazy_static! {
 }
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
-    ui.add_space(24.0);
-
+    ui.add_space(10.0);
+    ui.horizontal_wrapped(|ui| {
+        // ui.add_space(2.0);
+        ui.heading("My profile");
+    });
+    ui.add_space(10.0);
     let public_key = match GLOBALS.signer.public_key() {
         Some(pk) => pk,
         None => {

--- a/gossip-bin/src/ui/you/mod.rs
+++ b/gossip-bin/src/ui/you/mod.rs
@@ -14,7 +14,7 @@ mod metadata;
 pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     if app.page == Page::YourKeys {
         ui.add_space(10.0);
-        ui.heading("Your Keys");
+        ui.heading("My Keys");
 
         ui.add_space(10.0);
         ui.separator();


### PR DESCRIPTION
I uniformed the view's title to have a coherent UI and avoid the flickering at the top, when switching areas.
I didn't touch the DM chat because it is under review in another branch, and the People one because it needs a complete makeover.

@bu5hm4nn I think  we need to build a layout/component to manage the basic view structure (title-header, body, scrolling); I will open an issue to track this.