### PR TITLE
Install from brew/scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ See instructions for [Build from Source](#building-from-source).
 
 #### With Package Managers
 
-On **Arch Linux** with `pacman`: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
+With `pacman` on **Arch Linux**: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
 
-On **MacOS** or **Linux** with [homebrew](https://brew.sh/): `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)
+With [homebrew](https://brew.sh/) on **MacOS** or **Linux**: `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)
 
-On **Microsoft Windows** with [scoop](https://scoop.sh/): `gossip` from [`scoop-nostr`](https://github.com/nostorg/scoop-nostr)
+With [scoop](https://scoop.sh/) on **Microsoft Windows**: `gossip` from [`scoop-nostr`](https://github.com/nostorg/scoop-nostr)
 
 ```
 scoop bucket add nostr https://github.com/nostorg/scoop-nostr

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ See instructions for [Build from Source](#building-from-source).
 
 #### With Package Managers
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/gossip-nostr.svg)](https://repology.org/project/gossip-nostr/versions)
+
 With `pacman` on **Arch Linux**: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
 
 With [homebrew](https://brew.sh/) on **MacOS** or **Linux**: `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ See instructions for [Build from Source](#building-from-source).
 
 #### With Package Managers
 
-On **Arch Linux**: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
+On **Arch Linux** with `pacman`: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
 
-On **MacOS** or **Linux**: `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)
+On **MacOS** or **Linux** with [homebrew](https://brew.sh/): `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)
 
-On **Microsoft Windows**: `gossip` from [`scoop-nostr`](https://github.com/nostorg/scoop-nostr)
+On **Microsoft Windows** with [scoop](https://scoop.sh/): `gossip` from [`scoop-nostr`](https://github.com/nostorg/scoop-nostr)
 
 ```
 scoop bucket add nostr https://github.com/nostorg/scoop-nostr

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See instructions for [Build from Source](#building-from-source).
 
 On **Arch Linux**: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
 
-On **Macos**: `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)
+On **MacOS** or **Linux**: `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)
 
 On **Microsoft Windows**: `gossip` from [`scoop-nostr`](https://github.com/nostorg/scoop-nostr)
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,27 @@ Nostr stands for "Notes and Other Stuff Transmitted by Relays."
 
 ### Installing
 
-- **Arch Linux**: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
+See instructions for [Build from Source](#building-from-source).
+
+#### With Release Builds
+
 - **Debian**: See the [releases](https://github.com/mikedilger/gossip/releases) area for a file named something like `gossip-VERSION-ARCH.deb`
 - **Any Linux**: See the [releases](https://github.com/mikedilger/gossip/releases) area for a file named something like `gossip.VERSION.AppImage`
 - **Microsoft Windows**: See the [releases](https://github.com/mikedilger/gossip/releases) area for a file named something like `gossip.VERSION.msi`
 - **MacOS**: See the [releases](https://github.com/mikedilger/gossip/releases) area for a file named something like `gossip-VERSION-Darwin-arm64.dmg` or `gossip-VERSION-Darwin-x86_64.dmg`
 
-or choose to [Build from Source](#building-from-source)
+#### With Package Managers
+
+On **Arch Linux**: [`gossip`](https://aur.archlinux.org/packages/gossip) or [`gossip-git`](https://aur.archlinux.org/packages/gossip-git) or [`gossip-bin`](https://aur.archlinux.org/packages/gossip-bin) on the AUR
+
+On **Macos**: `brew install gossip` from [`homebrew-core`](https://github.com/Homebrew/homebrew-core), or for more options `brew install nostorg/nostr/gossip` from [`homebrew-nostr`](https://github.com/nostorg/homebrew-nostr)
+
+On **Microsoft Windows**: `gossip` from [`scoop-nostr`](https://github.com/nostorg/scoop-nostr)
+
+```
+scoop bucket add nostr https://github.com/nostorg/scoop-nostr
+scoop install gossip
+```
 
 ### Points of Difference
 


### PR DESCRIPTION
Formula was finally approved for `homebrew-core`!

For scoop this can be simplified with an official repository once my PR goes through eventually (https://github.com/ScoopInstaller/Extras/pull/11914)