### PR TITLE
Load more

### DIFF
--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -67,12 +67,6 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
                 if with_replies { "main" } else { "general" }
             );
             ui.add_space(10.0);
-            if ui.link("Load More").clicked() {
-                let _ = GLOBALS
-                    .to_overlord
-                    .send(ToOverlordMessage::LoadMoreGeneralFeed);
-            }
-            ui.add_space(10.0);
             ui.allocate_ui_with_layout(
                 Vec2::new(ui.available_width(), ui.spacing().interact_size.y),
                 egui::Layout::left_to_right(egui::Align::Center),
@@ -249,6 +243,19 @@ fn render_a_feed(
                                 is_last: Some(id) == last,
                             },
                         );
+                    }
+                    if !feed.is_empty() {
+                        ui.add_space(50.0);
+                        ui.with_layout(egui::Layout::top_down(egui::Align::Center).with_cross_align(egui::Align::Center), |ui| {
+                            app.theme.accent_button_1_style(ui.style_mut());
+                            ui.spacing_mut().button_padding.x *= 3.0;
+                            ui.spacing_mut().button_padding.y *= 2.0;
+                            if ui.add(egui::Button::new("Load More")).clicked() {
+                                let _ = GLOBALS
+                                    .to_overlord
+                                    .send(ToOverlordMessage::LoadMoreGeneralFeed);
+                            }
+                        });
                     }
                 });
             ui.add_space(100.0);

--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -67,6 +67,12 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
                 if with_replies { "main" } else { "general" }
             );
             ui.add_space(10.0);
+            if ui.link("Load More").clicked() {
+                let _ = GLOBALS
+                    .to_overlord
+                    .send(ToOverlordMessage::LoadMoreGeneralFeed);
+            }
+            ui.add_space(10.0);
             ui.allocate_ui_with_layout(
                 Vec2::new(ui.available_width(), ui.spacing().interact_size.y),
                 egui::Layout::left_to_right(egui::Align::Center),
@@ -103,12 +109,6 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
             );
             ui.add_space(6.0);
             render_a_feed(app, ctx, frame, ui, feed, false, &id);
-
-            if ui.link("Load More").clicked() {
-                let _ = GLOBALS
-                    .to_overlord
-                    .send(ToOverlordMessage::LoadMoreGeneralFeed);
-            }
         }
         FeedKind::Inbox(indirect) => {
             if app.settings.public_key.is_none() {

--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -250,11 +250,22 @@ fn render_a_feed(
                             app.theme.accent_button_1_style(ui.style_mut());
                             ui.spacing_mut().button_padding.x *= 3.0;
                             ui.spacing_mut().button_padding.y *= 2.0;
-                            if ui.add(egui::Button::new("Load More")).clicked() {
+                            let response = ui.add(egui::Button::new("Load More"));
+                            if response.clicked() {
                                 let _ = GLOBALS
                                     .to_overlord
                                     .send(ToOverlordMessage::LoadMoreGeneralFeed);
                             }
+
+                            // draw some nice lines left and right of the button
+                            let stroke = egui::Stroke::new( 1.5, ui.visuals().extreme_bg_color);
+                            let width = (ui.available_width() - response.rect.width()) / 2.0 - 20.0;
+                            let left_start = response.rect.left_center() - egui::vec2( 10.0, 0.0);
+                            let left_end = left_start - egui::vec2(width, 0.0);
+                            ui.painter().line_segment([left_start, left_end], stroke);
+                            let right_start = response.rect.right_center() + egui::vec2( 10.0, 0.0);
+                            let right_end = right_start + egui::vec2(width, 0.0);
+                            ui.painter().line_segment([right_start, right_end], stroke);
                         });
                     }
                 });

--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -2,6 +2,7 @@ use super::theme::FeedProperties;
 use super::{GossipUi, Page};
 use eframe::egui;
 use egui::{Context, Frame, RichText, Ui, Vec2};
+use gossip_lib::comms::ToOverlordMessage;
 use gossip_lib::FeedKind;
 use gossip_lib::GLOBALS;
 use nostr_types::Id;
@@ -102,6 +103,12 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
             );
             ui.add_space(6.0);
             render_a_feed(app, ctx, frame, ui, feed, false, &id);
+
+            if ui.link("Load More").clicked() {
+                let _ = GLOBALS
+                    .to_overlord
+                    .send(ToOverlordMessage::LoadMoreGeneralFeed);
+            }
         }
         FeedKind::Inbox(indirect) => {
             if app.settings.public_key.is_none() {

--- a/gossip-bin/src/ui/settings/content.rs
+++ b/gossip-bin/src/ui/settings/content.rs
@@ -12,7 +12,7 @@ pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Fr
 
     ui.horizontal(|ui| {
         ui.label("Feed Chunk: ").on_hover_text("This is the amount of time backwards from now that we will load events from. You'll eventually be able to load more, one chunk at a time. Mostly takes effect on restart.");
-        ui.add(Slider::new(&mut app.settings.feed_chunk, 600..=86400).text("seconds, "));
+        ui.add(Slider::new(&mut app.settings.feed_chunk, 1800..=43200).text("seconds, "));
         ui.label(secs_to_string(app.settings.feed_chunk));
     });
 

--- a/gossip-lib/src/comms.rs
+++ b/gossip-lib/src/comms.rs
@@ -80,6 +80,9 @@ pub enum ToOverlordMessage {
     /// Calls [like](crate::Overlord::like)
     Like(Id, PublicKey),
 
+    /// Calls [load_more_general_feed](crate::Overlord::load_more_general_feed)
+    LoadMoreGeneralFeed,
+
     /// internal (minions use this channel too)
     MinionJobComplete(RelayUrl, u64),
 

--- a/gossip-lib/src/comms.rs
+++ b/gossip-lib/src/comms.rs
@@ -208,6 +208,7 @@ pub(crate) enum ToMinionPayloadDetail {
     SubscribePersonFeed(PublicKey),
     SubscribeThreadFeed(IdHex, Vec<IdHex>),
     SubscribeDmChannel(DmChannel),
+    TempSubscribeGeneralFeedChunk(Vec<PublicKey>),
     TempSubscribeMetadata(Vec<PublicKey>),
     UnsubscribePersonFeed,
     UnsubscribeThreadFeed,

--- a/gossip-lib/src/overlord/mod.rs
+++ b/gossip-lib/src/overlord/mod.rs
@@ -171,6 +171,12 @@ impl Overlord {
                 .store(false, Ordering::Relaxed);
         }
 
+        // Init a feed variable
+        let now = Unixtime::now().unwrap();
+        let general_feed_start =
+            now - Duration::from_secs(GLOBALS.storage.read_setting_feed_chunk());
+        GLOBALS.feed.set_general_feed_start(general_feed_start);
+
         // Start the fetcher
         crate::fetcher::Fetcher::start()?;
 

--- a/gossip-lib/src/storage/mod.rs
+++ b/gossip-lib/src/storage/mod.rs
@@ -704,7 +704,7 @@ impl Storage {
     );
     def_setting!(num_relays_per_person, b"num_relays_per_person", u8, 2);
     def_setting!(max_relays, b"max_relays", u8, 50);
-    def_setting!(feed_chunk, b"feed_chunk", u64, 60 * 60 * 12);
+    def_setting!(feed_chunk, b"feed_chunk", u64, 60 * 60 * 4);
     def_setting!(replies_chunk, b"replies_chunk", u64, 60 * 60 * 24 * 7);
     def_setting!(
         person_feed_chunk,


### PR DESCRIPTION
"Load More" added to the general (following / lists) feed.  Not yet to the others.

Default chunk now 4 hours instead of 12.

The UI is totally wrong --  I wanted the button at the bottom of the feed but it didn't render there. So I just stuck it at the top for now.

It does a temp subscription to load all the events in the chunk you are asking about, from all the "follow" relays for all the subscribed keys on each relay.... it doesn't have any way to know if those events already existed in your database. So it's more expensive if you run gossip often as it loads them all again (because the final chunk always starts at the last EOSE which might be very recently, rather than say 4 hours ago, but we can't use that trick for older chunks).