### PR TITLE
Fix Clippy warning about non-canonical PartialOrd

### DIFF
--- a/gossip-lib/src/storage/types/person1.rs
+++ b/gossip-lib/src/storage/types/person1.rs
@@ -96,10 +96,7 @@ impl PartialEq for Person1 {
 impl Eq for Person1 {}
 impl PartialOrd for Person1 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match (self.display_name(), other.display_name()) {
-            (Some(a), Some(b)) => a.to_lowercase().partial_cmp(&b.to_lowercase()),
-            _ => self.pubkey.partial_cmp(&other.pubkey),
-        }
+        Some(self.cmp(other))
     }
 }
 impl Ord for Person1 {

--- a/gossip-lib/src/storage/types/person2.rs
+++ b/gossip-lib/src/storage/types/person2.rs
@@ -134,10 +134,7 @@ impl PartialEq for Person2 {
 impl Eq for Person2 {}
 impl PartialOrd for Person2 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match (self.tag_name(), other.tag_name()) {
-            (Some(a), Some(b)) => a.to_lowercase().partial_cmp(&b.to_lowercase()),
-            _ => self.pubkey.partial_cmp(&other.pubkey),
-        }
+        Some(self.cmp(other))
     }
 }
 impl Ord for Person2 {


### PR DESCRIPTION
With the latest Rust compiler, this makes compilation fail.

See https://rust-lang.github.io/rust-clippy/master/index.html#/non_canonical_partial_ord_impl