### PR TITLE
Pubkey-only mode: Support pulling contact list and rename "setup your…

### DIFF
--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -178,7 +178,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
                 ui.add_space(10.0);
                 ui.horizontal_wrapped(|ui| {
                     ui.label("You need to ");
-                    if ui.link("setup your identity").clicked() {
+                    if ui.link("setup your private-key").clicked() {
                         app.set_page(ctx, Page::YourKeys);
                     }
                     ui.label(" to see DMs.");

--- a/gossip-bin/src/ui/feed/post.rs
+++ b/gossip-bin/src/ui/feed/post.rs
@@ -119,7 +119,7 @@ pub(in crate::ui) fn posting_area(
                     you::offer_unlock_priv_key(app, ui);
                 } else {
                     ui.label("You need to ");
-                    if ui.link("setup your identity").clicked() {
+                    if ui.link("setup your private-key").clicked() {
                         app.set_page(ctx, Page::YourKeys);
                     }
                     ui.label(" to post.");

--- a/gossip-bin/src/ui/people/list.rs
+++ b/gossip-bin/src/ui/people/list.rs
@@ -116,44 +116,44 @@ pub(super) fn update(
 
     ui.set_enabled(enabled);
 
-    if GLOBALS.signer.is_ready() {
-        ui.vertical(|ui| {
-            ui.label(RichText::new(&app.people_list.cache_remote_tag))
-                .on_hover_text("This is the data in the latest list event fetched from relays");
+    ui.vertical(|ui| {
+        ui.label(RichText::new(&app.people_list.cache_remote_tag))
+            .on_hover_text("This is the data in the latest list event fetched from relays");
 
-            ui.add_space(5.0);
+        ui.add_space(5.0);
 
-            // remote <-> local buttons
-            ui.horizontal(|ui|{
-                if ui
-                    .button("↓ Overwrite ↓")
-                    .on_hover_text(
-                        "This imports data from the latest event, erasing anything that is already here",
-                    )
-                    .clicked()
-                {
-                    let _ = GLOBALS
-                        .to_overlord
-                        .send(ToOverlordMessage::UpdatePersonList {
-                            person_list: list,
-                            merge: false,
-                        });
-                }
-                if ui
-                    .button("↓ Merge ↓")
-                    .on_hover_text(
-                        "This imports data from the latest event, merging it into what is already here",
-                    )
-                    .clicked()
-                {
-                    let _ = GLOBALS
-                        .to_overlord
-                        .send(ToOverlordMessage::UpdatePersonList {
-                            person_list: list,
-                            merge: true,
-                        });
-                }
+        // remote <-> local buttons
+        ui.horizontal(|ui|{
+            if ui
+                .button("↓ Overwrite ↓")
+                .on_hover_text(
+                    "This imports data from the latest event, erasing anything that is already here",
+                )
+                .clicked()
+            {
+                let _ = GLOBALS
+                    .to_overlord
+                    .send(ToOverlordMessage::UpdatePersonList {
+                        person_list: list,
+                        merge: false,
+                    });
+            }
+            if ui
+                .button("↓ Merge ↓")
+                .on_hover_text(
+                    "This imports data from the latest event, merging it into what is already here",
+                )
+                .clicked()
+            {
+                let _ = GLOBALS
+                    .to_overlord
+                    .send(ToOverlordMessage::UpdatePersonList {
+                        person_list: list,
+                        merge: true,
+                    });
+            }
 
+            if GLOBALS.signer.is_ready() {
                 if ui
                     .button("↑ Publish ↑")
                     .on_hover_text("This publishes the list to your relays")
@@ -163,23 +163,23 @@ pub(super) fn update(
                         .to_overlord
                         .send(ToOverlordMessage::PushPersonList(list));
                 }
-            });
-
-            ui.add_space(5.0);
-
-            // local timestamp
-            ui.label(RichText::new(&app.people_list.cache_local_tag))
-                .on_hover_text("This is the local (and effective) list");
-        });
-    } else {
-        ui.horizontal(|ui| {
-            ui.label("You need to ");
-            if ui.link("setup your identity").clicked() {
-                app.set_page(ctx, Page::YourKeys);
+            } else {
+                ui.horizontal(|ui| {
+                    ui.label("You need to ");
+                    if ui.link("setup your private-key").clicked() {
+                        app.set_page(ctx, Page::YourKeys);
+                    }
+                    ui.label(" to push lists.");
+                });
             }
-            ui.label(" to manage list events.");
         });
-    }
+
+        ui.add_space(5.0);
+
+        // local timestamp
+        ui.label(RichText::new(&app.people_list.cache_local_tag))
+            .on_hover_text("This is the local (and effective) list");
+    });
 
     ui.add_space(10.0);
 

--- a/gossip-lib/src/overlord/mod.rs
+++ b/gossip-lib/src/overlord/mod.rs
@@ -2775,11 +2775,11 @@ impl Overlord {
         lnurl: UncheckedUrl,
     ) -> Result<(), Error> {
         if GLOBALS.signer.public_key().is_none() {
-            tracing::warn!("You need to setup your identity to zap.");
+            tracing::warn!("You need to setup your private-key to zap.");
             GLOBALS
                 .status_queue
                 .write()
-                .write("You need to setup your identity to zap.".to_string());
+                .write("You need to setup your private-key to zap.".to_string());
             *GLOBALS.current_zap.write() = ZapState::None;
             return Ok(());
         }
@@ -2839,11 +2839,11 @@ impl Overlord {
         let user_pubkey = match GLOBALS.signer.public_key() {
             Some(pk) => pk,
             None => {
-                tracing::warn!("You need to setup your identity to zap.");
+                tracing::warn!("You need to setup your private-key to zap.");
                 GLOBALS
                     .status_queue
                     .write()
-                    .write("You need to setup your identity to zap.".to_string());
+                    .write("You need to setup your private-key to zap.".to_string());
                 *GLOBALS.current_zap.write() = ZapState::None;
                 return Ok(());
             }


### PR DESCRIPTION
When in "pubkey only mode", make sure the buttons "merge" and "overwrite" are shown.
This branch also renames "setup your identity" to "setup your private-key" for clarity and to make sense when running in "pubkey only mode".