### PR TITLE
Fix/issue 628 selected relay reset

### DIFF
--- a/gossip-bin/src/ui/mod.rs
+++ b/gossip-bin/src/ui/mod.rs
@@ -817,6 +817,7 @@ impl GossipUi {
             | Page::RelaysCoverage
             | Page::RelaysMine
             | Page::RelaysKnownNetwork => {
+                self.relays.enter_page();
                 self.open_menu(ctx, SubMenu::Relays);
             }
             Page::Search => {

--- a/gossip-bin/src/ui/relays/mod.rs
+++ b/gossip-bin/src/ui/relays/mod.rs
@@ -55,6 +55,16 @@ impl RelayUi {
             new_relay_url: RELAY_URL_PREPOPULATE.to_string(),
         }
     }
+
+    pub(super) fn enter_page(&mut self) {
+        // preserve search and filter but reset edits and dialogues
+        self.edit = None;
+        self.edit_relays = Vec::new();
+        self.edit_done = None;
+        self.edit_needs_scroll = false;
+        self.add_dialog_step = AddRelayDialogStep::Inactive;
+        self.new_relay_url = RELAY_URL_PREPOPULATE.to_string();
+    }
 }
 
 #[derive(PartialEq, Default)]


### PR DESCRIPTION
Reset variables related to relay editing when switching pages in the relay section. Should fix #628.