### PR TITLE
Fix/egui native dpi detection

### DIFF
--- a/gossip-bin/src/ui/settings/mod.rs
+++ b/gossip-bin/src/ui/settings/mod.rs
@@ -36,17 +36,26 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
             }
 
             if ui.button("SAVE CHANGES").clicked() {
+                let mut dpi_changed = false;
+
                 // Apply DPI change
                 if stored_settings.override_dpi != app.unsaved_settings.override_dpi {
                     if let Some(value) = app.unsaved_settings.override_dpi {
                         let ppt: f32 = value as f32 / 72.0;
                         ctx.set_pixels_per_point(ppt);
+                        dpi_changed = true;
                     }
                 }
 
-                // Save new original DPI value
-                if let Some(value) = app.unsaved_settings.override_dpi {
-                    app.original_dpi_value = value;
+                // restore native if not overriding
+                // this can now be done with the new 'zoom_factor' egui setting
+                if !app.override_dpi {
+                    ctx.set_zoom_factor(1.0);
+                    dpi_changed = true;
+                }
+
+                if dpi_changed {
+                    app.init_scaling(ctx);
                 }
 
                 let _ = app.unsaved_settings.save();

--- a/gossip-bin/src/ui/settings/ui.rs
+++ b/gossip-bin/src/ui/settings/ui.rs
@@ -47,9 +47,15 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
         ui.checkbox(&mut app.override_dpi, "Override to ");
         ui.add(Slider::new(&mut app.override_dpi_value, 72..=250).text("DPI"));
 
-        if ui.button("Apply this change now (without saving)").clicked() {
+        if ui.button("Test (without saving)").clicked() {
             let ppt: f32 = app.override_dpi_value as f32 / 72.0;
             ctx.set_pixels_per_point(ppt);
+        }
+
+        if ui.button("Reset native").clicked() {
+            let native_ppt = ctx.native_pixels_per_point().unwrap_or(1.0);
+            app.override_dpi_value = (native_ppt * 72.0) as u32;
+            ctx.set_pixels_per_point(native_ppt);
         }
 
         // transfer to app.unsaved_settings


### PR DESCRIPTION
Detecting native DPI was broken in the new egui, because with egui 0.24 the native DPI is None until the Viewport is created. So this PR moves the DPI initialization to a new function called `App::init_scaling()` called on the first run of `App::update()`.

It also makes sure that `App::init_scaling()` is called when the user changes DPI settings.

Also DPI settings now offers a convenient button to revert back to native scaling.