### PR TITLE
Fix bug when saving scaling settings

### DIFF
--- a/gossip-bin/src/ui/settings/mod.rs
+++ b/gossip-bin/src/ui/settings/mod.rs
@@ -54,11 +54,13 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
                     dpi_changed = true;
                 }
 
+                if let Err(e) = app.unsaved_settings.save() {
+                    tracing::error!("Error saving settings: {}", e);
+                }
+
                 if dpi_changed {
                     app.init_scaling(ctx);
                 }
-
-                let _ = app.unsaved_settings.save();
             }
         }
     });


### PR DESCRIPTION
call `App::init_scaling()` after saving the settings because it reads the settings