### PR TITLE
Streamline onboarding wizard

### DIFF
--- a/gossip-bin/src/commands.rs
+++ b/gossip-bin/src/commands.rs
@@ -926,7 +926,7 @@ pub fn login() -> Result<(), Error> {
             Some(epk) => epk,
             None => return Err(ErrorKind::NoPrivateKey.into()),
         };
-        GLOBALS.identity.set_encrypted_private_key(epk)?;
+        GLOBALS.identity.set_encrypted_private_key(epk, &password)?;
         GLOBALS.identity.unlock(&password)?;
         password.zeroize();
     } else {

--- a/gossip-bin/src/ui/wizard/follow_people.rs
+++ b/gossip-bin/src/ui/wizard/follow_people.rs
@@ -250,39 +250,25 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
     ui.label("  • Profile (nprofile1..)");
     ui.label("  • DNS ID (user@domain)");
 
+    if app.wizard_state.has_private_key {
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {
+            ui.checkbox(
+                &mut app.wizard_state.follow_list_should_publish,
+                "Publish Following List",
+            );
+        });
+    }
+
     ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {
-        if app.wizard_state.has_private_key {
-            ui.scope(|ui| {
-                if app.wizard_state.new_user {
-                    app.theme.accent_button_1_style(ui.style_mut());
-                } else {
-                    app.theme.accent_button_2_style(ui.style_mut());
-                }
-                if ui.button("Publish and Finish").clicked() {
-                    let _ = GLOBALS
-                        .to_overlord
-                        .send(ToOverlordMessage::PushPersonList(PersonList::Followed));
-
-                    super::complete_wizard(app, ctx);
-                }
-            });
-
-            ui.add_space(20.0);
-            ui.scope(|ui| {
-                if !app.wizard_state.new_user {
-                    app.theme.accent_button_1_style(ui.style_mut());
-                } else {
-                    app.theme.accent_button_2_style(ui.style_mut());
-                }
-                if ui.button("Finish without publishing").clicked() {
-                    super::complete_wizard(app, ctx);
-                }
-            });
-        } else {
-            app.theme.accent_button_1_style(ui.style_mut());
-            if ui.button("Finish").clicked() {
-                super::complete_wizard(app, ctx);
+        app.theme.accent_button_1_style(ui.style_mut());
+        if ui.button("Finish").clicked() {
+            if app.wizard_state.follow_list_should_publish {
+                let _ = GLOBALS
+                    .to_overlord
+                    .send(ToOverlordMessage::PushPersonList(PersonList::Followed));
             }
+
+            super::complete_wizard(app, ctx);
         }
     });
 }

--- a/gossip-bin/src/ui/wizard/follow_people.rs
+++ b/gossip-bin/src/ui/wizard/follow_people.rs
@@ -1,9 +1,12 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use crate::ui::wizard::WizardPage;
 use crate::ui::{widgets, GossipUi, Page};
 use eframe::egui;
 use egui::{Context, RichText, Ui};
 use gossip_lib::comms::ToOverlordMessage;
-use gossip_lib::{Person, PersonList, GLOBALS};
+use gossip_lib::{PersonList, GLOBALS};
 use gossip_relay_picker::Direction;
 use nostr_types::{Profile, PublicKey};
 
@@ -24,102 +27,152 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
         app.wizard_state.contacts_sought = false;
     }
 
+    // Retrieve `Person` records
+    // this will take the (Some(Pubkey), None) tuple
+    // and turn it into a (None, Some(Person)) tuple
+    for iter in app.wizard_state.followed.iter_mut() {
+        if iter.1.is_none() {
+            let pk = iter.0.unwrap();
+            if let Ok(Some(p)) = GLOBALS.storage.read_person(&pk) {
+                iter.0 = None;
+                iter.1 = Some(Rc::new(RefCell::new(p)));
+            }
+        }
+    }
+
+    let mut followed = app.wizard_state.followed.clone();
+
+    ui.heading(format!(
+        "People Followed ({}):",
+        app.wizard_state.followed.len()
+    ));
     ui.add_space(10.0);
-    ui.heading(format!("Followed ({}):", app.wizard_state.followed.len()));
 
     egui::ScrollArea::new([false, true])
         .max_width(f32::INFINITY)
-        .max_height(0.4 * ctx.screen_rect().height())
+        .max_height(ctx.screen_rect().height() - 400.0)
         .show(ui, |ui| {
-            for iter in app.wizard_state.followed.iter_mut() {
-                // use cached person dataset
-                let person = if let Some(person) = &iter.1 {
-                    person
-                } else {
-                    let pk = iter.0.unwrap();
-                    let person = match GLOBALS.storage.read_person(&pk) {
-                        Ok(Some(p)) => p,
-                        Ok(None) => Person::new(pk),
-                        Err(_) => Person::new(pk),
-                    };
-                    iter.0 = None;
-                    iter.1 = Some(person.to_owned());
-                    iter.1.as_ref().unwrap()
-                };
+            for iter in followed.iter_mut() {
+                if iter.1.is_none() {
+                    continue;
+                }
 
+                let person = iter.1.as_mut().unwrap();
                 widgets::list_entry::make_frame(ui, Some(app.theme.main_content_bgcolor())).show(
                     ui,
                     |ui| {
+                        let pubkey = person.borrow().pubkey;
                         ui.horizontal(|ui| {
-                            if let Some(metadata) = &person.metadata {
-                                // We have metadata, render their name
-                                if let Some(name) = &metadata.name {
-                                    ui.label(name);
-                                } else {
-                                    ui.label(person.pubkey.as_hex_string());
-                                }
+                            // Avatar first
+                            let avatar = if let Some(avatar) = app.try_get_avatar(ctx, &pubkey) {
+                                avatar
                             } else {
-                                // We don't have metadata
-                                if let Ok(outboxes) = GLOBALS
-                                    .storage
-                                    .get_best_relays(person.pubkey, Direction::Write)
-                                {
-                                    if !outboxes.is_empty() {
-                                        // But we have their outboxes
-                                        if !app
-                                            .wizard_state
-                                            .followed_getting_metadata
-                                            .contains(&person.pubkey)
+                                app.placeholder_avatar.clone()
+                            };
+
+                            widgets::paint_avatar(
+                                ui,
+                                &person.borrow(),
+                                &avatar,
+                                widgets::AvatarSize::Feed,
+                            );
+
+                            ui.add_space(20.0);
+
+                            ui.vertical(|ui| {
+                                ui.add_space(5.0);
+                                ui.horizontal(|ui| {
+                                    ui.label(RichText::new(person.borrow().best_name()).size(15.5));
+
+                                    ui.add_space(10.0);
+
+                                    if person.borrow().metadata.is_none() {
+                                        // We don't have metadata
+                                        if let Ok(outboxes) = GLOBALS
+                                            .storage
+                                            .get_best_relays(pubkey, Direction::Write)
                                         {
-                                            tracing::warn!(
-                                                "seek metadata for {}",
-                                                person.pubkey.as_hex_string()
+                                            if !outboxes.is_empty() {
+                                                // But we have their outboxes
+                                                if !app
+                                                    .wizard_state
+                                                    .followed_getting_metadata
+                                                    .contains(&pubkey)
+                                                {
+                                                    // Add this key to the list of metadata to be updated
+                                                    app.wizard_state
+                                                        .followed_getting_metadata
+                                                        .insert(pubkey.to_owned());
+                                                }
+                                                ui.label(
+                                                    RichText::new("seeking metadata...").color(
+                                                        app.theme.warning_marker_text_color(),
+                                                    ),
+                                                );
+                                            } else {
+                                                // We don't have outboxes... this will come. Following them triggered this.
+                                                ui.label(
+                                                    RichText::new("seeking relay list...").color(
+                                                        app.theme.warning_marker_text_color(),
+                                                    ),
+                                                );
+                                            }
+                                        } else {
+                                            // We don't have outboxes... this will come. Following them triggered this.
+                                            ui.label(
+                                                RichText::new("seeking relay list...")
+                                                    .color(app.theme.warning_marker_text_color()),
                                             );
-                                            // // And we haven't asked for metadata yet,
-                                            // // trigger fetch of their metadata
-                                            // let _ = GLOBALS.to_overlord.send(
-                                            //     ToOverlordMessage::UpdateMetadata(person.pubkey),
-                                            // );
-                                            // then remember we did so we don't keep doing it over and over again
-                                            app.wizard_state
-                                                .followed_getting_metadata
-                                                .insert(person.pubkey.to_owned());
                                         }
-                                        ui.label(format!(
-                                            "{} [seeking metadata]",
-                                            person.pubkey.as_hex_string()
-                                        ));
-                                    } else {
-                                        // We don't have outboxes... this will come. Following them triggered this.
-                                        ui.label(format!(
-                                            "{} [seeking their relay list]",
-                                            person.pubkey.as_hex_string()
-                                        ));
                                     }
-                                } else {
-                                    // We don't have outboxes... this will come. Following them triggered this.
-                                    ui.label(format!(
-                                        "{} [seeking their relay list]",
-                                        person.pubkey.as_hex_string()
-                                    ));
-                                }
-                            }
+                                });
+                                ui.add_space(3.0);
+                                ui.label(
+                                    GossipUi::richtext_from_person_nip05(&person.borrow()).weak(),
+                                );
+                            });
+
+                            ui.vertical(|ui| {
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Min)
+                                        .with_cross_align(egui::Align::Center),
+                                    |ui| {
+                                        widgets::MoreMenu::simple(ui, app).show(
+                                            ui,
+                                            |ui, is_open| {
+                                                // actions
+                                                if ui.button("Remove").clicked() {
+                                                    let _ =
+                                                        GLOBALS.storage.remove_person_from_list(
+                                                            &pubkey,
+                                                            PersonList::Followed,
+                                                            None,
+                                                        );
+                                                    *is_open = false;
+                                                }
+                                            },
+                                        );
+                                    },
+                                );
+                            });
                         });
                     },
                 );
-
-                // refresh pending metadata
-                let uitime = ctx.input(|i| i.time);
-                if (app.wizard_state.followed_last_try + 5.0) < uitime {
-                    let list = app.wizard_state.followed_getting_metadata.drain();
-                    let _ = GLOBALS
-                        .to_overlord
-                        .send(ToOverlordMessage::UpdateMetadataInBulk(list.collect()));
-                    app.wizard_state.followed_getting_metadata.clear();
-                    app.wizard_state.followed_last_try = uitime;
-                }
             }
         });
+
+    // refresh pending metadata
+    // TODO this is a workaround because the overlord would stop processing
+    // if it hit a relay that wanted authentication
+    let uitime = ctx.input(|i| i.time);
+    if (app.wizard_state.followed_last_try + 5.0) < uitime {
+        let list = app.wizard_state.followed_getting_metadata.drain();
+        let _ = GLOBALS
+            .to_overlord
+            .send(ToOverlordMessage::UpdateMetadataInBulk(list.collect()));
+        app.wizard_state.followed_getting_metadata.clear();
+        app.wizard_state.followed_last_try = uitime;
+    }
 
     ui.add_space(10.0);
     ui.separator();
@@ -127,49 +180,56 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
 
     ui.horizontal(|ui| {
         ui.label("Follow Someone:");
-        let response = text_edit_line!(app, app.add_contact)
-            .with_paste()
-            .hint_text(
-                "Enter a key (bech32 npub1 or hex), or an nprofile, or a DNS id (user@domain)",
-            )
-            .show(ui)
-            .response;
-        if response.changed() {
-            app.wizard_state.error = None;
-        }
-        if ui.button("follow").clicked() {
-            if let Ok(pubkey) = PublicKey::try_from_bech32_string(app.add_contact.trim(), true) {
-                let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowPubkey(
-                    pubkey,
-                    PersonList::Followed,
-                    true,
-                ));
-            } else if let Ok(pubkey) = PublicKey::try_from_hex_string(app.add_contact.trim(), true)
-            {
-                let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowPubkey(
-                    pubkey,
-                    PersonList::Followed,
-                    true,
-                ));
-            } else if let Ok(profile) =
-                Profile::try_from_bech32_string(app.add_contact.trim(), true)
-            {
-                let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowNprofile(
-                    profile,
-                    PersonList::Followed,
-                    true,
-                ));
-            } else if gossip_lib::nip05::parse_nip05(app.add_contact.trim()).is_ok() {
-                let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowNip05(
-                    app.add_contact.trim().to_owned(),
-                    PersonList::Followed,
-                    true,
-                ));
-            } else {
-                app.wizard_state.error = Some("ERROR: Invalid pubkey".to_owned());
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {
+            app.theme.accent_button_2_style(ui.style_mut());
+            if ui.button("follow").clicked() {
+                if let Ok(pubkey) = PublicKey::try_from_bech32_string(app.add_contact.trim(), true)
+                {
+                    let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowPubkey(
+                        pubkey,
+                        PersonList::Followed,
+                        true,
+                    ));
+                } else if let Ok(pubkey) =
+                    PublicKey::try_from_hex_string(app.add_contact.trim(), true)
+                {
+                    let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowPubkey(
+                        pubkey,
+                        PersonList::Followed,
+                        true,
+                    ));
+                } else if let Ok(profile) =
+                    Profile::try_from_bech32_string(app.add_contact.trim(), true)
+                {
+                    let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowNprofile(
+                        profile,
+                        PersonList::Followed,
+                        true,
+                    ));
+                } else if gossip_lib::nip05::parse_nip05(app.add_contact.trim()).is_ok() {
+                    let _ = GLOBALS.to_overlord.send(ToOverlordMessage::FollowNip05(
+                        app.add_contact.trim().to_owned(),
+                        PersonList::Followed,
+                        true,
+                    ));
+                } else {
+                    app.wizard_state.error = Some("ERROR: Invalid pubkey".to_owned());
+                }
+                app.add_contact = "".to_owned();
             }
-            app.add_contact = "".to_owned();
-        }
+            ui.add_space(10.0);
+            let response = text_edit_line!(app, app.add_contact)
+                .desired_width(ui.available_width())
+                .with_paste()
+                .hint_text(
+                    "Enter a key (bech32 npub1 or hex), or an nprofile, or a DNS id (user@domain)",
+                )
+                .show(ui)
+                .response;
+            if response.changed() {
+                app.wizard_state.error = None;
+            }
+        });
     });
 
     // error block
@@ -190,34 +250,39 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
     ui.label("  • Profile (nprofile1..)");
     ui.label("  • DNS ID (user@domain)");
 
-    if app.wizard_state.has_private_key {
-        ui.add_space(20.0);
-        let mut label = RichText::new("  >  Publish and Finish");
-        if app.wizard_state.new_user {
-            label = label.color(app.theme.accent_color());
-        }
-        if ui.button(label).clicked() {
-            let _ = GLOBALS
-                .to_overlord
-                .send(ToOverlordMessage::PushPersonList(PersonList::Followed));
+    ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {
+        if app.wizard_state.has_private_key {
+            ui.scope(|ui| {
+                if app.wizard_state.new_user {
+                    app.theme.accent_button_1_style(ui.style_mut());
+                } else {
+                    app.theme.accent_button_2_style(ui.style_mut());
+                }
+                if ui.button("Publish and Finish").clicked() {
+                    let _ = GLOBALS
+                        .to_overlord
+                        .send(ToOverlordMessage::PushPersonList(PersonList::Followed));
 
-            super::complete_wizard(app, ctx);
-        }
+                    super::complete_wizard(app, ctx);
+                }
+            });
 
-        ui.add_space(20.0);
-        let mut label = RichText::new("  >  Finish without publishing");
-        if !app.wizard_state.new_user {
-            label = label.color(app.theme.accent_color());
+            ui.add_space(20.0);
+            ui.scope(|ui| {
+                if !app.wizard_state.new_user {
+                    app.theme.accent_button_1_style(ui.style_mut());
+                } else {
+                    app.theme.accent_button_2_style(ui.style_mut());
+                }
+                if ui.button("Finish without publishing").clicked() {
+                    super::complete_wizard(app, ctx);
+                }
+            });
+        } else {
+            app.theme.accent_button_1_style(ui.style_mut());
+            if ui.button("Finish").clicked() {
+                super::complete_wizard(app, ctx);
+            }
         }
-        if ui.button(label).clicked() {
-            super::complete_wizard(app, ctx);
-        }
-    } else {
-        ui.add_space(20.0);
-        let mut label = RichText::new("  >  Finish");
-        label = label.color(app.theme.accent_color());
-        if ui.button(label).clicked() {
-            super::complete_wizard(app, ctx);
-        }
-    }
+    });
 }

--- a/gossip-bin/src/ui/wizard/follow_people.rs
+++ b/gossip-bin/src/ui/wizard/follow_people.rs
@@ -257,6 +257,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
                 "Publish Following List",
             );
         });
+        ui.add_space(10.0);
     }
 
     ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {

--- a/gossip-bin/src/ui/wizard/import_keys.rs
+++ b/gossip-bin/src/ui/wizard/import_keys.rs
@@ -1,7 +1,11 @@
+use crate::ui::widgets::list_entry::{self};
 use crate::ui::wizard::WizardPage;
 use crate::ui::{GossipUi, Page};
 use eframe::egui;
-use egui::{Context, RichText, Ui};
+use egui::{Context, Ui};
+
+use super::wizard_controls;
+use super::wizard_state::WizardPath;
 
 pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     if app.wizard_state.pubkey.is_some() {
@@ -9,24 +13,76 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
         return;
     };
 
-    ui.add_space(20.0);
+    let selected = app.wizard_state.path == WizardPath::ImportFromKey(true);
+    let response = list_entry::make_frame(ui, None)
+        .stroke(if selected {
+            egui::Stroke::new(1.0, app.theme.accent_color())
+        } else {
+            egui::Stroke::new(1.0, egui::Color32::TRANSPARENT)
+        })
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+            ui.horizontal(|ui| {
+                ui.add(egui::RadioButton::new(selected, ""));
+                ui.add_space(10.0);
+                ui.label("Import a Private Key")
+                    .on_hover_cursor(egui::CursorIcon::Default);
+            })
+        });
     if ui
-        .button(RichText::new("  >  Import a Private Key").color(app.theme.accent_color()))
+        .interact(
+            response.response.rect,
+            ui.next_auto_id(),
+            egui::Sense::click(),
+        )
         .clicked()
     {
-        app.set_page(ctx, Page::Wizard(WizardPage::ImportPrivateKey));
+        app.wizard_state.path = WizardPath::ImportFromKey(true);
+    }
+
+    let selected = app.wizard_state.path == WizardPath::ImportFromKey(false);
+    let response = list_entry::make_frame(ui, None)
+        .stroke(if selected {
+            egui::Stroke::new(1.0, app.theme.accent_color())
+        } else {
+            egui::Stroke::new(1.0, egui::Color32::TRANSPARENT)
+        })
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+            ui.horizontal(|ui| {
+                ui.add(egui::RadioButton::new(selected, ""));
+                ui.add_space(10.0);
+                ui.label("Import a Public Key")
+                    .on_hover_cursor(egui::CursorIcon::Default);
+            })
+        });
+    if ui
+        .interact(
+            response.response.rect,
+            ui.next_auto_id(),
+            egui::Sense::click(),
+        )
+        .clicked()
+    {
+        app.wizard_state.path = WizardPath::ImportFromKey(false);
     }
 
     ui.add_space(20.0);
-    if ui
-        .button(RichText::new("  >  Import a Public Key only").color(app.theme.accent_color()))
-        .clicked()
-    {
-        app.set_page(ctx, Page::Wizard(WizardPage::ImportPublicKey));
-    }
-
-    ui.add_space(20.0);
-    if ui.button("  <  Go Back").clicked() {
-        app.set_page(ctx, Page::Wizard(WizardPage::WelcomeGossip));
-    }
+    wizard_controls(
+        ui,
+        app,
+        true,
+        |app| {
+            app.set_page(ctx, Page::Wizard(WizardPage::WelcomeGossip));
+        },
+        |app| match app.wizard_state.path {
+            super::wizard_state::WizardPath::ImportFromKey(true) => {
+                app.set_page(ctx, Page::Wizard(WizardPage::ImportPrivateKey));
+            }
+            super::wizard_state::WizardPath::ImportFromKey(false) => {
+                app.set_page(ctx, Page::Wizard(WizardPage::ImportPublicKey));
+            }
+            _ => {}
+        },
+    );
 }

--- a/gossip-bin/src/ui/wizard/import_private_key.rs
+++ b/gossip-bin/src/ui/wizard/import_private_key.rs
@@ -100,6 +100,9 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
     if let Some(err) = &app.wizard_state.error {
         ui.add_space(10.0);
         ui.label(RichText::new(err).color(app.theme.warning_marker_text_color()));
+        if ncryptsec {
+            ui.label("Please check your ncryptsec and password again");
+        }
     }
 
     wizard_controls(
@@ -110,12 +113,11 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
             app.set_page(ctx, Page::Wizard(WizardPage::ImportKeys));
         },
         |app| {
+            app.wizard_state.error = None;
             let _ = GLOBALS.to_overlord.send(ToOverlordMessage::ImportPriv {
                 privkey: app.import_priv.clone(),
                 password: app.password.clone(),
             });
-            app.import_priv.zeroize();
-            app.import_priv = "".to_owned();
             app.password.zeroize();
             app.password = "".to_owned();
             app.password2.zeroize();

--- a/gossip-bin/src/ui/wizard/mod.rs
+++ b/gossip-bin/src/ui/wizard/mod.rs
@@ -166,24 +166,34 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
     egui::CentralPanel::default()
         .frame({
             let frame = egui::Frame::central_panel(&app.theme.get_style());
-            frame.inner_margin(egui::Margin {
-                left: 20.0,
-                right: 10.0,
-                top: 10.0,
-                bottom: 0.0,
+            frame.inner_margin({
+                #[cfg(not(target_os = "macos"))]
+                let margin = egui::Margin {
+                    left: 20.0,
+                    right: 20.0,
+                    top: 20.0,
+                    bottom: 0.0,
+                };
+                #[cfg(target_os = "macos")]
+                let margin = egui::Margin {
+                    left: 20.0,
+                    right: 20.0,
+                    top: 35.0,
+                    bottom: 0.0,
+                };
+                margin
             })
         })
         .show(ctx, |ui| {
-            ui.add_space(24.0);
-            ui.heading(wp.as_str());
-            ui.add_space(12.0);
-            /*
-            if let Some(err) = app.wizard_state.error {
-            ui.label(RichText::new(err).color(app.theme.warning_marker_text_color()));
-            ui.add_space(12.0);
+            match wp {
+                WizardPage::FollowPeople => {},
+                _ => {
+                    ui.heading(wp.as_str());
+                    ui.add_space(12.0);
+                },
             }
-            */
-            ui.separator();
+
+            // ui.separator();
 
             match wp {
                 WizardPage::WelcomeGossip => welcome_gossip::update(app, ctx, frame, ui),

--- a/gossip-bin/src/ui/wizard/mod.rs
+++ b/gossip-bin/src/ui/wizard/mod.rs
@@ -197,13 +197,6 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, frame: &mut eframe::Fram
                 WizardPage::FollowPeople => follow_people::update(app, ctx, frame, ui),
             }
 
-            ui.add_space(20.0);
-            if wp != WizardPage::FollowPeople {
-                if ui.button("  X  Exit this Wizard").clicked() {
-                    complete_wizard(app, ctx);
-                }
-            }
-
             ui.add_space(10.0);
             ui.separator();
             ui.add_space(10.0);

--- a/gossip-bin/src/ui/wizard/read_nostr_config.rs
+++ b/gossip-bin/src/ui/wizard/read_nostr_config.rs
@@ -53,8 +53,8 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
         }
     });
 
-    if app.wizard_state.need_relay_list() && !app.wizard_state.relay_list_sought {
-        app.wizard_state.relay_list_sought = true;
+    if app.wizard_state.need_relay_list() && app.wizard_state.relay_list_sought {
+        app.wizard_state.relay_list_sought = false;
 
         let discovery_relays: Vec<RelayUrl> = app
             .wizard_state

--- a/gossip-bin/src/ui/wizard/setup_relays.rs
+++ b/gossip-bin/src/ui/wizard/setup_relays.rs
@@ -258,7 +258,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
         let mut label = RichText::new("  >  Continue");
         label = label.color(app.theme.accent_color());
         if ui.button(label).clicked() {
-            app.set_page(ctx, Page::Wizard(WizardPage::SetupMetadata));
+            app.set_page(ctx, Page::Wizard(WizardPage::FollowPeople));
         };
     }
 }

--- a/gossip-bin/src/ui/wizard/setup_relays.rs
+++ b/gossip-bin/src/ui/wizard/setup_relays.rs
@@ -1,7 +1,7 @@
-use super::{continue_control, modify_relay};
+use super::modify_relay;
 use crate::ui::widgets::list_entry::OUTER_MARGIN_RIGHT;
-use crate::ui::wizard::{WizardPage, DEFAULT_RELAYS};
-use crate::ui::{GossipUi, Page};
+use crate::ui::wizard::DEFAULT_RELAYS;
+use crate::ui::GossipUi;
 use eframe::egui;
 use egui::{Button, Color32, Context, RichText, Ui};
 use egui_winit::egui::vec2;
@@ -241,31 +241,30 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
             );
         });
         ui.add_space(10.0);
-        continue_control(ui, app, true, |app| {
-            if app.wizard_state.relays_should_publish {
+    }
+
+    ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {
+        ui.add_space(OUTER_MARGIN_RIGHT);
+        app.theme.accent_button_1_style(ui.style_mut());
+        if ui
+            .add(egui::Button::new("Finish").min_size(vec2(80.0, 0.0)))
+            .clicked()
+        {
+            if app.wizard_state.has_private_key && app.wizard_state.relays_should_publish {
                 let _ = GLOBALS
                     .to_overlord
                     .send(ToOverlordMessage::AdvertiseRelayList);
             }
-            app.set_page(ctx, Page::Wizard(WizardPage::SetupMetadata));
-        });
-    } else {
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {
-            ui.add_space(OUTER_MARGIN_RIGHT);
-            app.theme.accent_button_1_style(ui.style_mut());
-            if ui
-                .add(egui::Button::new("Finish").min_size(vec2(80.0, 0.0)))
-                .clicked()
-            {
-                // import existing lists and start the app
-                let _ = GLOBALS
-                    .to_overlord
-                    .send(ToOverlordMessage::UpdatePersonList {
-                        person_list: PersonList::Followed,
-                        merge: false,
-                    });
-                super::complete_wizard(app, ctx);
-            }
-        });
-    }
+
+            // import existing lists and start the app
+            let _ = GLOBALS
+                .to_overlord
+                .send(ToOverlordMessage::UpdatePersonList {
+                    person_list: PersonList::Followed,
+                    merge: false,
+                });
+
+            super::complete_wizard(app, ctx);
+        }
+    });
 }

--- a/gossip-bin/src/ui/wizard/welcome_gossip.rs
+++ b/gossip-bin/src/ui/wizard/welcome_gossip.rs
@@ -1,8 +1,12 @@
+use crate::ui::widgets::list_entry::{self, OUTER_MARGIN_RIGHT};
 use crate::ui::wizard::WizardPage;
 use crate::ui::{GossipUi, Page};
 use eframe::egui;
-use egui::{Context, RichText, Ui};
+use egui::{Context, Ui};
 use gossip_lib::GLOBALS;
+
+use super::continue_button;
+use super::wizard_state::WizardPath;
 
 pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     if app.wizard_state.pubkey.is_some() {
@@ -17,35 +21,77 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
     ui.label("Please select from the following choices:");
 
     ui.add_space(20.0);
-    if ui
-        .button(RichText::new("  >  Create a New Nostr Account").color(app.theme.accent_color()))
-        .clicked()
-    {
-        app.wizard_state.new_user = true;
-        app.set_page(ctx, Page::Wizard(WizardPage::WelcomeNostr));
-    }
 
-    ui.add_space(20.0);
+    render_wizard_path_choice(ui, app, WizardPath::CreateNewAccount);
+
+    render_wizard_path_choice(ui, app, WizardPath::ImportFromKey(true));
+
+    render_wizard_path_choice(ui, app, WizardPath::FollowOnlyNoKeys);
+
+    ui.add_space(20.0); // vertical space
+    ui.horizontal(|ui| {
+        if ui.button("Exit Setup Wizard").clicked() {
+            super::complete_wizard(app, ctx);
+        }
+
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::default()), |ui| {
+            app.theme.accent_button_1_style(ui.style_mut());
+            ui.add_space(OUTER_MARGIN_RIGHT);
+            if ui.add(continue_button()).clicked() {
+                match app.wizard_state.path {
+                    WizardPath::CreateNewAccount => {
+                        app.wizard_state.new_user = true;
+                        app.set_page(ctx, Page::Wizard(WizardPage::WelcomeNostr));
+                    }
+                    WizardPath::ImportFromKey(_) => {
+                        app.wizard_state.new_user = false;
+                        app.set_page(ctx, Page::Wizard(WizardPage::ImportKeys))
+                    }
+                    WizardPath::FollowOnlyNoKeys => {
+                        app.wizard_state.new_user = false;
+                        app.wizard_state.follow_only = true;
+                        let _ = GLOBALS.storage.set_flag_following_only(true, None);
+                        app.set_page(ctx, Page::Wizard(WizardPage::FollowPeople));
+                    }
+                }
+            }
+        });
+    });
+}
+
+fn wizard_path_name(path: WizardPath) -> &'static str {
+    match path {
+        WizardPath::CreateNewAccount => "Create a New Nostr Account",
+        WizardPath::ImportFromKey(_) => "I Already have a Nostr Account",
+        WizardPath::FollowOnlyNoKeys => "Just follow people (no account)",
+    }
+}
+
+fn render_wizard_path_choice(ui: &mut Ui, app: &mut GossipUi, choice: WizardPath) {
+    let selected = app.wizard_state.path == choice;
+    let response = list_entry::make_frame(ui, None)
+        .stroke(if selected {
+            egui::Stroke::new(1.0, app.theme.accent_color())
+        } else {
+            egui::Stroke::new(1.0, egui::Color32::TRANSPARENT)
+        })
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+            ui.horizontal(|ui| {
+                ui.add(egui::RadioButton::new(selected, ""));
+                ui.add_space(10.0);
+                ui.label(wizard_path_name(choice))
+                    .on_hover_cursor(egui::CursorIcon::Default);
+            })
+        });
     if ui
-        .button(
-            RichText::new("  >  I Already have a Nostr Account").color(app.theme.accent_color()),
+        .interact(
+            response.response.rect,
+            ui.next_auto_id(),
+            egui::Sense::click(),
         )
         .clicked()
     {
-        app.wizard_state.new_user = false;
-        app.set_page(ctx, Page::Wizard(WizardPage::ImportKeys))
-    }
-
-    ui.add_space(20.0);
-    if ui.button("  >  Just follow people (no account)").clicked() {
-        app.wizard_state.new_user = false;
-        app.wizard_state.follow_only = true;
-        let _ = GLOBALS.storage.set_flag_following_only(true, None);
-        app.set_page(ctx, Page::Wizard(WizardPage::FollowPeople));
-    }
-
-    ui.add_space(20.0);
-    if ui.button("  X  Exit this Wizard").clicked() {
-        super::complete_wizard(app, ctx);
+        app.wizard_state.path = choice;
     }
 }

--- a/gossip-bin/src/ui/wizard/welcome_gossip.rs
+++ b/gossip-bin/src/ui/wizard/welcome_gossip.rs
@@ -43,4 +43,9 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
         let _ = GLOBALS.storage.set_flag_following_only(true, None);
         app.set_page(ctx, Page::Wizard(WizardPage::FollowPeople));
     }
+
+    ui.add_space(20.0);
+    if ui.button("  X  Exit this Wizard").clicked() {
+        super::complete_wizard(app, ctx);
+    }
 }

--- a/gossip-bin/src/ui/wizard/wizard_state.rs
+++ b/gossip-bin/src/ui/wizard/wizard_state.rs
@@ -2,8 +2,21 @@ use gossip_lib::{Person, PersonList, Relay, GLOBALS};
 use nostr_types::{Event, EventKind, PublicKey, RelayUrl};
 use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum WizardPath {
+    /// the user wants to import an existing account from
+    /// a private (true) or public key (false)
+    ImportFromKey(bool),
+    /// the user wants to create a new account
+    CreateNewAccount,
+    /// the user only wants to create a local follow list
+    /// without setting up any keys
+    FollowOnlyNoKeys,
+}
+
 #[derive(Debug)]
 pub struct WizardState {
+    pub path: WizardPath,
     pub error: Option<String>,
     pub last_status_queue_message: String,
     pub new_user: bool,
@@ -14,15 +27,18 @@ pub struct WizardState {
     pub metadata_name: String,
     pub metadata_about: String,
     pub metadata_picture: String,
+    pub metadata_should_publish: bool,
     pub pubkey: Option<PublicKey>,
     pub has_private_key: bool,
     pub metadata_events: Vec<Event>,
     pub contact_list_events: Vec<Event>,
     pub relay_list_events: Vec<Event>,
     pub relays: Vec<Relay>,
+    pub relays_should_publish: bool,
     pub followed: Vec<(Option<PublicKey>, Option<Rc<RefCell<Person>>>)>,
     pub followed_last_try: f64,
     pub followed_getting_metadata: HashSet<PublicKey>,
+    pub follow_list_should_publish: bool,
     pub contacts_sought: bool,
     pub generating: bool,
 }
@@ -30,6 +46,7 @@ pub struct WizardState {
 impl Default for WizardState {
     fn default() -> WizardState {
         WizardState {
+            path: WizardPath::CreateNewAccount,
             error: None,
             last_status_queue_message: "".to_owned(),
             new_user: false,
@@ -40,15 +57,18 @@ impl Default for WizardState {
             metadata_name: "".to_owned(),
             metadata_about: "".to_owned(),
             metadata_picture: "".to_owned(),
+            metadata_should_publish: true,
             pubkey: None,
             has_private_key: false,
             metadata_events: Vec::new(),
             contact_list_events: Vec::new(),
             relay_list_events: Vec::new(),
             relays: Vec::new(),
+            relays_should_publish: true,
             followed: Vec::new(),
             followed_last_try: 0.0,
             followed_getting_metadata: HashSet::new(),
+            follow_list_should_publish: true,
             contacts_sought: true,
             generating: false,
         }

--- a/gossip-bin/src/ui/wizard/wizard_state.rs
+++ b/gossip-bin/src/ui/wizard/wizard_state.rs
@@ -1,4 +1,4 @@
-use gossip_lib::{PersonList, Relay, GLOBALS};
+use gossip_lib::{Person, PersonList, Relay, GLOBALS};
 use nostr_types::{Event, EventKind, PublicKey, RelayUrl};
 use std::collections::HashSet;
 
@@ -20,7 +20,8 @@ pub struct WizardState {
     pub contact_list_events: Vec<Event>,
     pub relay_list_events: Vec<Event>,
     pub relays: Vec<Relay>,
-    pub followed: Vec<PublicKey>,
+    pub followed: Vec<(Option<PublicKey>, Option<Person>)>,
+    pub followed_last_try: f64,
     pub followed_getting_metadata: HashSet<PublicKey>,
     pub contacts_sought: bool,
     pub generating: bool,
@@ -46,6 +47,7 @@ impl Default for WizardState {
             relay_list_events: Vec::new(),
             relays: Vec::new(),
             followed: Vec::new(),
+            followed_last_try: 0.0,
             followed_getting_metadata: HashSet::new(),
             contacts_sought: true,
             generating: false,
@@ -86,7 +88,7 @@ impl WizardState {
             .get_people_in_list(PersonList::Followed)
             .unwrap_or_default()
             .drain(..)
-            .map(|(pk, _)| pk)
+            .map(|(pk, _)| (Some(pk), None))
             .collect();
 
         if self.need_discovery_relays() {

--- a/gossip-bin/src/ui/wizard/wizard_state.rs
+++ b/gossip-bin/src/ui/wizard/wizard_state.rs
@@ -1,6 +1,6 @@
 use gossip_lib::{Person, PersonList, Relay, GLOBALS};
 use nostr_types::{Event, EventKind, PublicKey, RelayUrl};
-use std::collections::HashSet;
+use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
 #[derive(Debug)]
 pub struct WizardState {
@@ -20,7 +20,7 @@ pub struct WizardState {
     pub contact_list_events: Vec<Event>,
     pub relay_list_events: Vec<Event>,
     pub relays: Vec<Relay>,
-    pub followed: Vec<(Option<PublicKey>, Option<Person>)>,
+    pub followed: Vec<(Option<PublicKey>, Option<Rc<RefCell<Person>>>)>,
     pub followed_last_try: f64,
     pub followed_getting_metadata: HashSet<PublicKey>,
     pub contacts_sought: bool,

--- a/gossip-lib/src/gossip_identity.rs
+++ b/gossip-lib/src/gossip_identity.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorKind};
+use crate::error::Error;
 use crate::globals::GLOBALS;
 use nostr_types::{
     ContentEncryptionAlgorithm, DelegationConditions, EncryptedPrivateKey, Event, EventKind,
@@ -104,13 +104,12 @@ impl GossipIdentity {
         Ok(())
     }
 
-    pub fn set_encrypted_private_key(&self, epk: EncryptedPrivateKey) -> Result<(), Error> {
-        let public_key = match *self.inner.read() {
-            Identity::None => return Err(ErrorKind::NoPublicKey.into()),
-            Identity::Public(public_key) => public_key,
-            Identity::Signer(ref s) => s.public_key(),
-        };
-        *self.inner.write() = Identity::from_locked_parts(public_key, epk);
+    pub fn set_encrypted_private_key(
+        &self,
+        epk: EncryptedPrivateKey,
+        pass: &str,
+    ) -> Result<(), Error> {
+        *self.inner.write() = Identity::from_encrypted_private_key(epk, pass)?;
         self.on_keychange()?;
         Ok(())
     }

--- a/gossip-lib/src/overlord/mod.rs
+++ b/gossip-lib/src/overlord/mod.rs
@@ -193,9 +193,6 @@ impl Overlord {
         // Start periodic tasks in pending
         crate::pending::start();
 
-        // Initialize the relay picker
-        GLOBALS.relay_picker.init().await?;
-
         // Do the startup procedures
         self.start_long_lived_subscriptions().await?;
 
@@ -2760,6 +2757,9 @@ impl Overlord {
 
     /// This is done at startup and after the wizard.
     pub async fn start_long_lived_subscriptions(&mut self) -> Result<(), Error> {
+        // Intialize the RelayPicker
+        GLOBALS.relay_picker.init().await?;
+
         // Pick Relays and start Minions
         if !GLOBALS.storage.read_setting_offline() {
             self.pick_relays().await;


### PR DESCRIPTION
Most importantly this branch includes the fix to make feeds work immediately after completing the wizard without restarting the app.

But it also turned into a streamline rework of the onboarding process ahead of @dtonon complete design review. Below are screen recordings of all 4 onboarding paths for easy review:

#### Create New Account
https://github.com/mikedilger/gossip/assets/3328670/f58ff272-480b-4b3e-b8ec-b6a4bd6c2a7c

#### Import Private Key
https://github.com/mikedilger/gossip/assets/3328670/964de25d-0a13-435b-bbc4-bd5ce50d37f9

#### Import Public Key
https://github.com/mikedilger/gossip/assets/3328670/5c5b0069-74e6-4770-8069-1ac04a4559ae

#### Follow Only
https://github.com/mikedilger/gossip/assets/3328670/5fd74187-00bc-4617-a52e-58e1c26e65bb


