### PR TITLE
Add right margin to the feed to make space for the scroll bar

### DIFF
--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -255,9 +255,16 @@ fn render_a_feed(
     };
 
     app.vert_scroll_area()
+        .auto_shrink(false)
         .id_source(scroll_area_id)
         .show(ui, |ui| {
             egui::Frame::none()
+                .outer_margin(egui::Margin {
+                    left: 0.0,
+                    right: 10.0,
+                    top: 0.0,
+                    bottom: 0.0,
+                })
                 .rounding(app.theme.feed_scroll_rounding(&feed_properties))
                 .fill(app.theme.feed_scroll_fill(&feed_properties))
                 .stroke(app.theme.feed_scroll_stroke(&feed_properties))

--- a/gossip-bin/src/ui/feed/mod.rs
+++ b/gossip-bin/src/ui/feed/mod.rs
@@ -98,7 +98,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, ui: &mut Ui) {
                     recompute_btn(ui);
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.add_space(10.0);
+                        ui.add_space(16.0);
 
                         if ui.button("Edit List").clicked() {
                             app.set_page(ctx, Page::PeopleList(list));
@@ -150,7 +150,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, ui: &mut Ui) {
                     recompute_btn(ui);
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.add_space(10.0);
+                        ui.add_space(16.0);
                         ui.label(RichText::new("Everything").size(11.0));
                         let size = ui.spacing().interact_size.y * egui::vec2(1.6, 0.8);
                         if widgets::switch_with_size(ui, &mut app.inbox_include_indirect, size)
@@ -261,7 +261,7 @@ fn render_a_feed(
             egui::Frame::none()
                 .outer_margin(egui::Margin {
                     left: 0.0,
-                    right: 10.0,
+                    right: 14.0,
                     top: 0.0,
                     bottom: 0.0,
                 })


### PR DESCRIPTION
@dtonon please see the commit in this branch to see where to adjust the right margin

<img width="1086" alt="Screenshot 2024-03-29 at 21 47 14" src="https://github.com/mikedilger/gossip/assets/3328670/8bc41b77-7e2e-4357-a73e-49ff61562369">
