### PR TITLE
Remove unused directory permission from flatpak

### DIFF
--- a/packaging/flatpak/com.mikedilger.gossip.yml
+++ b/packaging/flatpak/com.mikedilger.gossip.yml
@@ -14,7 +14,6 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --share=network
-  - --filesystem=home/.local/share/gossip:rw
 
 modules:
   - name: gossip


### PR DESCRIPTION
`dirs::data_dir()` prioritizes `XDG_DATA_HOME`, which is scoped by flatpak