### PR TITLE
feat: typos.toml + `typos` fixes

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,6 @@
+[files]
+extend-exclude = ["**/*.drawio", "fonts/**"]
+
+[default.extend-words]
+# Don't correct Mac Big Sur
+Sur = "Sur"

--- a/gossip-bin/src/commands.rs
+++ b/gossip-bin/src/commands.rs
@@ -495,12 +495,12 @@ pub fn delete_spam_by_content(
 
     let since = match args.next() {
         Some(s) => Unixtime(s.parse::<i64>()?),
-        None => return cmd.usage("Missing <since_unixtime> paramter".to_string()),
+        None => return cmd.usage("Missing <since_unixtime> parameter".to_string()),
     };
 
     let substring = match args.next() {
         Some(c) => c,
-        None => return cmd.usage("Missing <substring> paramter".to_string()),
+        None => return cmd.usage("Missing <substring> parameter".to_string()),
     };
 
     // If DM Chat, use GiftWrap

--- a/gossip-bin/src/ui/feed/note/content.rs
+++ b/gossip-bin/src/ui/feed/note/content.rs
@@ -263,8 +263,8 @@ pub(super) fn render_plain(
 }
 
 pub(super) fn render_profile_link(app: &mut GossipUi, ui: &mut Ui, pubkey: &PublicKey) {
-    let nam = gossip_lib::names::best_name_from_pubkey_lookup(pubkey);
-    if ui.link(&nam).clicked() {
+    let name = gossip_lib::names::best_name_from_pubkey_lookup(pubkey);
+    if ui.link(&name).clicked() {
         app.set_page(ui.ctx(), Page::Person(pubkey.to_owned()));
     };
 }
@@ -276,8 +276,8 @@ pub(super) fn render_event_link(
     link_to_id: Id,
 ) {
     let idhex: IdHex = link_to_id.into();
-    let nam = format!("#{}", gossip_lib::names::hex_id_short(&idhex));
-    if ui.link(&nam).clicked() {
+    let name = format!("#{}", gossip_lib::names::hex_id_short(&idhex));
+    if ui.link(&name).clicked() {
         app.set_page(
             ui.ctx(),
             Page::Feed(FeedKind::Thread {
@@ -295,9 +295,9 @@ pub(super) fn render_parameterized_event_link(
     referenced_by_id: Id,
     event_addr: &EventAddr,
 ) {
-    let nam = format!("[{:?}: {}]", event_addr.kind, event_addr.d);
-    //let nam = format!("nostr:{}", event_addr.as_bech32_string());
-    if ui.link(&nam).clicked() {
+    let name = format!("[{:?}: {}]", event_addr.kind, event_addr.d);
+    // let name = format!("nostr:{}", event_addr.as_bech32_string());
+    if ui.link(&name).clicked() {
         if let Ok(Some(prevent)) =
             GLOBALS
                 .storage

--- a/gossip-bin/src/ui/feed/note/mod.rs
+++ b/gossip-bin/src/ui/feed/note/mod.rs
@@ -307,8 +307,8 @@ pub fn render_note_inner(
                             ui.add_space(8.0);
                             ui.style_mut().override_text_style = Some(TextStyle::Small);
                             let idhex: IdHex = irt.into();
-                            let nam = format!("▲ #{}", gossip_lib::names::hex_id_short(&idhex));
-                            if ui.link(&nam).clicked() {
+                            let name = format!("▲ #{}", gossip_lib::names::hex_id_short(&idhex));
+                            if ui.link(&name).clicked() {
                                 app.set_page(
                                     ui.ctx(),
                                     Page::Feed(FeedKind::Thread {
@@ -329,8 +329,8 @@ pub fn render_note_inner(
                                 ui.add_space(8.0);
                                 ui.style_mut().override_text_style = Some(TextStyle::Small);
                                 let idhex: IdHex = e.id.into();
-                                let nam = format!("▲ #{}", gossip_lib::names::hex_id_short(&idhex));
-                                if ui.link(&nam).clicked() {
+                                let name = format!("▲ #{}", gossip_lib::names::hex_id_short(&idhex));
+                                if ui.link(&name).clicked() {
                                     app.set_page(
                                         ui.ctx(),
                                         Page::Feed(FeedKind::Thread {

--- a/gossip-bin/src/ui/mod.rs
+++ b/gossip-bin/src/ui/mod.rs
@@ -501,7 +501,7 @@ struct GossipUi {
     // Fully opened posts
     opened: HashSet<Id>,
 
-    // Visisble Note IDs
+    // Visible Note IDs
     // (we resubscribe to reactions/zaps/deletes when this changes)
     visible_note_ids: Vec<Id>,
     // This one is built up as rendering happens, then compared
@@ -510,7 +510,7 @@ struct GossipUi {
 
     // Zap state, computed once per frame instead of per note
     // zap_state and note_being_zapped are computed from GLOBALS.current_zap and are
-    //   not authoratative.
+    //   not authoritative.
     zap_state: ZapState,
     note_being_zapped: Option<Id>,
 
@@ -1954,7 +1954,7 @@ impl GossipUi {
         // Update when this happened, so we don't accept again too rapidly
         self.last_visible_update = Instant::now();
 
-        // Save to self.visibile_note_ids
+        // Save to self.visible_note_ids
         self.visible_note_ids = std::mem::take(&mut self.next_visible_note_ids);
 
         if !self.visible_note_ids.is_empty() {

--- a/gossip-bin/src/ui/settings/id.rs
+++ b/gossip-bin/src/ui/settings/id.rs
@@ -28,7 +28,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
     ui.add_space(20.0);
     ui.label("Encrypted Private Key scrypt N parameter");
     ui.label("(NOTE: changing this will not re-encrypt any existing encrypted private key)");
-    ui.add(Slider::new(&mut app.unsaved_settings.log_n, 18..=22).text("logN iteratons"));
+    ui.add(Slider::new(&mut app.unsaved_settings.log_n, 18..=22).text("logN iterations"));
 
     // Login at startup
     ui.add_space(20.0);

--- a/gossip-bin/src/ui/settings/ui.rs
+++ b/gossip-bin/src/ui/settings/ui.rs
@@ -17,7 +17,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
     );
     ui.checkbox(
         &mut app.unsaved_settings.feed_newest_at_bottom,
-        "Order feed with newest at bottom (intead of top)",
+        "Order feed with newest at bottom (instead of top)",
     );
 
     ui.add_space(20.0);

--- a/gossip-bin/src/ui/wizard/welcome_nostr.rs
+++ b/gossip-bin/src/ui/wizard/welcome_nostr.rs
@@ -27,7 +27,7 @@ pub(super) fn update(app: &mut GossipUi, ctx: &Context, _frame: &mut eframe::Fra
     ui.add_space(20.0);
     ui.heading("Generate a Keypair");
 
-    // compute results from previus ui update
+    // compute results from previous ui update
     let password_mismatch = app.password != app.password2;
     let ready = !password_mismatch;
 

--- a/gossip-lib/src/dm_channel.rs
+++ b/gossip-lib/src/dm_channel.rs
@@ -96,7 +96,7 @@ impl DmChannel {
     }
 }
 
-/// Data about a DM channel such as when the latest message occured, how many massages
+/// Data about a DM channel such as when the latest message occurred, how many massages
 /// it has, and how many are unread.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DmChannelData {

--- a/gossip-lib/src/overlord/minion/filter_fns.rs
+++ b/gossip-lib/src/overlord/minion/filter_fns.rs
@@ -294,7 +294,7 @@ pub fn metadata(pubkeys: &[PublicKey]) -> Vec<Filter> {
         authors: pkhp,
         kinds: vec![EventKind::Metadata, EventKind::RelayList],
         // FIXME: we could probably get a since-last-fetched-their-metadata here.
-        //        but relays should just return the lastest of these.
+        //        but relays should just return the latest of these.
         ..Default::default()
     }]
 }

--- a/gossip-lib/src/overlord/mod.rs
+++ b/gossip-lib/src/overlord/mod.rs
@@ -2518,7 +2518,7 @@ impl Overlord {
                             .to_overlord
                             .send(ToOverlordMessage::FetchEventAddr(ea.to_owned()));
 
-                        // FIXME - this requires eventaddr comparision on process.rs
+                        // FIXME - this requires eventaddr comparison on process.rs
                         // Remember we are searching for this event, so when it comes in
                         // it can get added to GLOBALS.note_search_results
                         // GLOBALS.event_addrs_being_searched_for.write().push(ea.to_owned());
@@ -2871,7 +2871,7 @@ impl Overlord {
 
     /// This is done at startup and after the wizard.
     pub async fn start_long_lived_subscriptions(&mut self) -> Result<(), Error> {
-        // Intialize the RelayPicker
+        // Initialize the RelayPicker
         GLOBALS.relay_picker.init().await?;
         GLOBALS.connected_relays.clear();
 

--- a/gossip-lib/src/people.rs
+++ b/gossip-lib/src/people.rs
@@ -113,7 +113,7 @@ impl People {
     /// (We also force the current user into this list)
     pub fn get_subscribed_pubkeys(&self) -> Vec<PublicKey> {
         // We subscribe to all people in all lists.
-        // This is no longer synonomous with the ContactList list
+        // This is no longer synonymous with the ContactList list
         match GLOBALS.storage.get_people_in_all_followed_lists() {
             Ok(mut people) => {
                 if let Some(pk) = GLOBALS.identity.public_key() {

--- a/gossip-lib/src/status.rs
+++ b/gossip-lib/src/status.rs
@@ -1,5 +1,5 @@
 /// A queue of up to three status messages for the UI, generally
-/// representing errors that occured in disconnected backend processes.
+/// representing errors that occurred in disconnected backend processes.
 pub struct StatusQueue {
     head: usize,
     messages: [String; 3],

--- a/gossip-lib/src/storage/mod.rs
+++ b/gossip-lib/src/storage/mod.rs
@@ -1376,7 +1376,7 @@ impl Storage {
                 }
 
                 // actual deletion done in second pass
-                // (deleting during interation does not work in LMDB)
+                // (deleting during iteration does not work in LMDB)
                 for deletion in deletions.drain(..) {
                     self.db_event_seen_on_relay()?.delete(txn, &deletion)?;
                 }
@@ -1492,7 +1492,7 @@ impl Storage {
     /// Find events by filter.
     ///
     /// This function may inefficiently scrape all of storage for some filters.
-    /// To avoid an inefficent scrape, do one of these
+    /// To avoid an inefficient scrape, do one of these
     ///
     /// 1. Supply some ids
     /// 2. Supply some authors and some kinds, or
@@ -2046,7 +2046,7 @@ impl Storage {
             }
         }
 
-        // Deletes via 'a tags (entire paramterized groups)
+        // Deletes via 'a tags (entire parameterized groups)
         if let Some(parameter) = maybe_deleted_event.parameter() {
             let addr = EventAddr {
                 d: parameter,

--- a/gossip-lib/src/storage/types/person_relay1.rs
+++ b/gossip-lib/src/storage/types/person_relay1.rs
@@ -32,10 +32,10 @@ pub struct PersonRelay1 {
     /// If they set 'write' on their relay list
     pub write: bool,
 
-    /// If the user manaully specified 'read' for this association
+    /// If the user manually specified 'read' for this association
     pub manually_paired_read: bool,
 
-    /// If the user manaully specified 'write' for this association
+    /// If the user manually specified 'write' for this association
     pub manually_paired_write: bool,
 }
 

--- a/packaging/RELEASE.md
+++ b/packaging/RELEASE.md
@@ -53,7 +53,7 @@
 
 1. Build the flatpak:
 
-    - Folllow the [Flatpak README](flatpak/README.md)
+    - Follow the [Flatpak README](flatpak/README.md)
 
 1. Build the windows:
 
@@ -135,7 +135,7 @@ gossip
    -- cargo clippy; cargo fmt
    -- FORK 0.N:
       -- all deps switch to released versions
-      -- verison 0.N
+      -- version 0.N
       -- package/publish (see below)
       -- version 0.N.1-unstable
    -- master

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -11,7 +11,7 @@ Compile:
   cargo build --features=lang-cjk --release
 ````
 
-Copy the binary to the packaging diretory
+Copy the binary to the packaging directory
 
 ````dos
   cp ..\..\target\release\gossip.exe .


### PR DESCRIPTION
First commit adds a `.typos.toml`, second commit fixes typos found by `typos` command.

Can also add typos checks into the precommit hooks and checks if you're cool with it in separate PR.