### PR TITLE
fix: opacity of add_post_icon to 2/3 for better visibility on light mode

### DIFF
--- a/gossip-bin/src/ui/mod.rs
+++ b/gossip-bin/src/ui/mod.rs
@@ -1286,7 +1286,7 @@ impl GossipUi {
                                     fill_color_tuple.0,
                                     fill_color_tuple.1,
                                     fill_color_tuple.2,
-                                    128, // half transparent
+                                    170, // 2/3 transparent
                                 )
                             };
                             let response = ui.add_sized(


### PR DESCRIPTION
This is the result in dark mode:

![Screenshot 2024-07-01 at 22 04 44](https://github.com/mikedilger/gossip/assets/1290639/f1930ec7-11c7-44a8-a081-71f7228824b7)

and this is the light mode:

![Screenshot 2024-07-01 at 22 05 36](https://github.com/mikedilger/gossip/assets/1290639/dd0b6f86-23a1-4d47-939f-5eca33e0ec80)

Uses 255*(2/3) as opacity instead of 255*(1/2)

fixes #728