### PR TITLE
Shows full path in case of a File Exists error

### DIFF
--- a/gossip-lib/src/profile.rs
+++ b/gossip-lib/src/profile.rs
@@ -112,10 +112,22 @@ impl Profile {
         };
 
         // Create all these directories if missing
-        fs::create_dir_all(&base_dir)?;
-        fs::create_dir_all(&cache_dir)?;
-        fs::create_dir_all(&profile_dir)?;
-        fs::create_dir_all(&lmdb_dir)?;
+        fs::create_dir_all(&base_dir).map_err(|e| {
+            eprintln!("Error creating base directory ({}): {}", base_dir.display(), e);
+            Error::from(format!("Failed to create base directory: {}", e))
+        })?;
+        fs::create_dir_all(&cache_dir).map_err(|e| {
+            eprintln!("Error creating cache directory ({}): {}", cache_dir.display(), e);
+            Error::from(format!("Failed to create cache directory: {}", e))
+        })?;
+        fs::create_dir_all(&profile_dir).map_err(|e| {
+            eprintln!("Error creating profile directory ({}): {}", profile_dir.display(), e);
+            Error::from(format!("Failed to create profile directory: {}", e))
+        })?;
+        fs::create_dir_all(&lmdb_dir).map_err(|e| {
+            eprintln!("Error creating LMDB directory ({}): {}", lmdb_dir.display(), e);
+            Error::from(format!("Failed to create LMDB directory: {}", e))
+        })?;
 
         let tmp_cache_dir = TempDir::new("cache")?;
 


### PR DESCRIPTION
When the system tries to create the configuration directories, it crashes if it fails (say because of regular file there or a broken symlink). The out put is "File Exists" which makes troubleshooting difficult.

With this change, gossip prints the full path of the problematic file so the user khows where to look.

fixes #856