### PR TITLE
UI - Adding the number of relays to the configure relay pages

### DIFF
--- a/gossip-bin/src/ui/relays/active.rs
+++ b/gossip-bin/src/ui/relays/active.rs
@@ -12,26 +12,34 @@ use nostr_types::RelayUrl;
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     let is_editing = app.relays.edit.is_some();
-    widgets::page_header(ui, Page::RelaysActivityMonitor.name(), |ui| {
-        if is_editing {
-            ui.disable();
-        }
-        super::configure_list_btn(app, ui);
-        btn_h_space!(ui);
-        super::relay_filter_combo(app, ui);
-        btn_h_space!(ui);
-        super::relay_sort_combo(app, ui);
-        btn_h_space!(ui);
-        widgets::TextEdit::search(&app.theme, &app.assets, &mut app.relays.search)
-            .desired_width(super::SEARCH_WIDTH)
-            .show(ui);
-        if widgets::Button::primary(&app.theme, "Add Relay")
-            .show(ui)
-            .clicked()
-        {
-            super::start_entry_dialog(app);
-        }
-    });
+    widgets::page_header(
+        ui,
+        &format!(
+            "{} ({} relays)",
+            Page::RelaysActivityMonitor.name(),
+            get_relays(app).len()
+        ),
+        |ui| {
+            if is_editing {
+                ui.disable();
+            }
+            super::configure_list_btn(app, ui);
+            btn_h_space!(ui);
+            super::relay_filter_combo(app, ui);
+            btn_h_space!(ui);
+            super::relay_sort_combo(app, ui);
+            btn_h_space!(ui);
+            widgets::TextEdit::search(&app.theme, &app.assets, &mut app.relays.search)
+                .desired_width(super::SEARCH_WIDTH)
+                .show(ui);
+            if widgets::Button::primary(&app.theme, "Add Relay")
+                .show(ui)
+                .clicked()
+            {
+                super::start_entry_dialog(app);
+            }
+        },
+    );
 
     let relays = if !is_editing {
         // clear edit cache if present

--- a/gossip-bin/src/ui/relays/known.rs
+++ b/gossip-bin/src/ui/relays/known.rs
@@ -8,26 +8,34 @@ use gossip_lib::GLOBALS;
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     let is_editing = app.relays.edit.is_some();
-    widgets::page_header(ui, Page::RelaysKnownNetwork(None).name(), |ui| {
-        if is_editing {
-            ui.disable();
-        }
-        super::configure_list_btn(app, ui);
-        btn_h_space!(ui);
-        super::relay_filter_combo(app, ui);
-        btn_h_space!(ui);
-        super::relay_sort_combo(app, ui);
-        btn_h_space!(ui);
-        widgets::TextEdit::search(&app.theme, &app.assets, &mut app.relays.search)
-            .desired_width(super::SEARCH_WIDTH)
-            .show(ui);
-        if widgets::Button::primary(&app.theme, "Add Relay")
-            .show(ui)
-            .clicked()
-        {
-            super::start_entry_dialog(app);
-        }
-    });
+    widgets::page_header(
+        ui,
+        &format!(
+            "{} ({} relays)",
+            Page::RelaysKnownNetwork(None).name(),
+            get_relays(app).len()
+        ),
+        |ui| {
+            if is_editing {
+                ui.disable();
+            }
+            super::configure_list_btn(app, ui);
+            btn_h_space!(ui);
+            super::relay_filter_combo(app, ui);
+            btn_h_space!(ui);
+            super::relay_sort_combo(app, ui);
+            btn_h_space!(ui);
+            widgets::TextEdit::search(&app.theme, &app.assets, &mut app.relays.search)
+                .desired_width(super::SEARCH_WIDTH)
+                .show(ui);
+            if widgets::Button::primary(&app.theme, "Add Relay")
+                .show(ui)
+                .clicked()
+            {
+                super::start_entry_dialog(app);
+            }
+        },
+    );
 
     // TBD time how long this takes. We don't want expensive code in the UI
     // FIXME keep more relay info and display it

--- a/gossip-bin/src/ui/relays/mine.rs
+++ b/gossip-bin/src/ui/relays/mine.rs
@@ -8,28 +8,36 @@ use gossip_lib::GLOBALS;
 
 pub(super) fn update(app: &mut GossipUi, _ctx: &Context, _frame: &mut eframe::Frame, ui: &mut Ui) {
     let is_editing = app.relays.edit.is_some();
-    widgets::page_header(ui, Page::RelaysMine.name(), |ui| {
-        if is_editing {
-            ui.disable();
-        }
-        super::configure_list_btn(app, ui);
-        btn_h_space!(ui);
-        super::relay_filter_combo(app, ui);
-        btn_h_space!(ui);
-        super::relay_sort_combo(app, ui);
-        btn_h_space!(ui);
-        widgets::TextEdit::search(&app.theme, &app.assets, &mut app.relays.search)
-            .desired_width(super::SEARCH_WIDTH)
-            .show(ui);
-        if widgets::Button::primary(&app.theme, "Add Relay")
-            .show(ui)
-            .clicked()
-        {
-            super::start_entry_dialog(app);
-        }
+    widgets::page_header(
+        ui,
+        &format!(
+            "{} ({} relays)",
+            Page::RelaysMine.name(),
+            get_relays(app).len()
+        ),
+        |ui| {
+            if is_editing {
+                ui.disable();
+            }
+            super::configure_list_btn(app, ui);
+            btn_h_space!(ui);
+            super::relay_filter_combo(app, ui);
+            btn_h_space!(ui);
+            super::relay_sort_combo(app, ui);
+            btn_h_space!(ui);
+            widgets::TextEdit::search(&app.theme, &app.assets, &mut app.relays.search)
+                .desired_width(super::SEARCH_WIDTH)
+                .show(ui);
+            if widgets::Button::primary(&app.theme, "Add Relay")
+                .show(ui)
+                .clicked()
+            {
+                super::start_entry_dialog(app);
+            }
 
-        // let advertise_remaining = GLOBALS.advertise_jobs_remaining.load(Ordering::Relaxed);
-    });
+            // let advertise_remaining = GLOBALS.advertise_jobs_remaining.load(Ordering::Relaxed);
+        },
+    );
 
     let relays = if !is_editing {
         // clear edit cache if present


### PR DESCRIPTION
Its done by replacing

`widgets::page_header(ui, Page::RelaysActivityMonitor.name(), |ui|`

with

`widgets::page_header(ui, &format!("{} ({} relays)", Page::RelaysMine.name(), get_relays(app).len()), |ui| {`

on relay pages but diff is longer because of linting.

closes #306