### PR TITLE
Add feature: right-click to copy link

### DIFF
--- a/gossip-bin/src/ui/feed/note/content/media.rs
+++ b/gossip-bin/src/ui/feed/note/content/media.rs
@@ -1,3 +1,4 @@
+use crate::ui::widgets::{self};
 use crate::ui::GossipUi;
 use eframe::{egui, epaint};
 use egui::{Image, Response, RichText, Ui};
@@ -46,29 +47,9 @@ pub fn show_image(
                 GLOBALS.status_queue.write().write("Fetch Media setting is disabled. Right-click link to open in browser or copy URL".to_owned());
             }
         }
-        // context menu
+
         response.context_menu(|ui| {
-            if ui.button("Open in browser").clicked() {
-                let modifiers = ui.ctx().input(|i| i.modifiers);
-                ui.ctx().output_mut(|o| {
-                    o.open_url = Some(egui::output::OpenUrl {
-                        url: url_string.clone(),
-                        new_tab: modifiers.any(),
-                    });
-                });
-            }
-            if ui.button("Copy URL").clicked() {
-                ui.output_mut(|o| o.copied_text = url_string.clone());
-            }
-            if let Some(error) = app.has_media_loading_failed(url_string.as_str()) {
-                if ui
-                    .button("Retry loading ...")
-                    .on_hover_text(error)
-                    .clicked()
-                {
-                    app.retry_media(&url);
-                }
-            }
+            widgets::show_media_link_context(ui, app, url);
         });
     }
 
@@ -122,29 +103,9 @@ pub fn show_video(
                 GLOBALS.status_queue.write().write("Fetch Media setting is disabled. Right-click link to open in browser or copy URL".to_owned());
             }
         }
-        // context menu
+
         response.context_menu(|ui| {
-            if ui.button("Open in browser").clicked() {
-                let modifiers = ui.ctx().input(|i| i.modifiers);
-                ui.ctx().output_mut(|o| {
-                    o.open_url = Some(egui::output::OpenUrl {
-                        url: url_string.clone(),
-                        new_tab: modifiers.any(),
-                    });
-                });
-            }
-            if ui.button("Copy URL").clicked() {
-                ui.output_mut(|o| o.copied_text = url_string.clone());
-            }
-            if let Some(error) = app.has_media_loading_failed(url_string.as_str()) {
-                if ui
-                    .button("Retry loading ...")
-                    .on_hover_text(error)
-                    .clicked()
-                {
-                    app.retry_media(&url);
-                }
-            }
+            widgets::show_media_link_context(ui, app, url);
         });
     }
 

--- a/gossip-bin/src/ui/feed/note/content/mod.rs
+++ b/gossip-bin/src/ui/feed/note/content/mod.rs
@@ -270,10 +270,10 @@ pub(super) fn render_hyperlink(
                 media::show_video(app, ui, nurl, privacy_issue, note.volatile, file_metadata);
             }
         } else {
-            crate::ui::widgets::break_anywhere_hyperlink_to(ui, link, link);
+            crate::ui::widgets::break_anywhere_hyperlink_to(ui, app, link, link);
         }
     } else {
-        crate::ui::widgets::break_anywhere_hyperlink_to(ui, link, link);
+        crate::ui::widgets::break_anywhere_hyperlink_to(ui, app, link, link);
     }
 }
 

--- a/gossip-bin/src/ui/feed/note/mod.rs
+++ b/gossip-bin/src/ui/feed/note/mod.rs
@@ -732,7 +732,7 @@ pub fn render_note_inside_framing(
                                 ui.add(Label::new(
                                     RichText::new(format!("proxied from {}: ", proxy)).color(color),
                                 ));
-                                crate::ui::widgets::break_anywhere_hyperlink_to(ui, &id, &id);
+                                crate::ui::widgets::break_anywhere_hyperlink_to(ui, app, &id, &id);
                             });
                         });
                 }

--- a/gossip-bin/src/ui/help/about.rs
+++ b/gossip-bin/src/ui/help/about.rs
@@ -39,11 +39,15 @@ We are storing data on your system in this directory: {}. This data is only used
 
         ui.add_space(22.0);
 
-        ui.hyperlink_to("Learn More about Nostr", "https://github.com/nostr-protocol/nostr");
+        crate::ui::widgets::break_anywhere_hyperlink_to(ui, app,
+            "Learn More about Nostr",
+            "https://github.com/nostr-protocol/nostr");
 
         ui.add_space(30.0);
 
-        ui.hyperlink_to("Source Code", &app.about.homepage);
+        crate::ui::widgets::break_anywhere_hyperlink_to(ui, app,
+            "Source Code",
+            app.about.homepage.clone());
         ui.label(RichText::new("by").text_style(TextStyle::Small));
         ui.label(RichText::new(app.about.authors.replace(':', "\n")).text_style(TextStyle::Small));
 

--- a/gossip-bin/src/ui/mod.rs
+++ b/gossip-bin/src/ui/mod.rs
@@ -2660,14 +2660,14 @@ fn force_login(app: &mut GossipUi, ctx: &Context) {
                             ui.label(
                                 RichText::new("Do you need help? Open an").weak()
                             );
-                            ui.hyperlink_to(
+                            crate::ui::widgets::break_anywhere_hyperlink_to(ui, app,
                                 "issue on Github",
                                 "https://github.com/mikedilger/gossip/issues"
                             );
                             ui.label(
                                 RichText::new("or join our").weak()
                             );
-                            ui.hyperlink_to(
+                            crate::ui::widgets::break_anywhere_hyperlink_to(ui, app,
                                 "chat",
                                 "https://chachi.chat/groups.0xchat.com/R2yYwhsTcKO2b65i"
                             );

--- a/gossip-bin/src/ui/mod.rs
+++ b/gossip-bin/src/ui/mod.rs
@@ -1697,8 +1697,8 @@ impl GossipUi {
         GLOBALS.media.check_url(unchecked_url)
     }
 
-    pub fn retry_media(&self, url: &Url) {
-        GLOBALS.media.retry_failed(&url.to_unchecked_url());
+    pub fn retry_media(&self, url: Url) {
+        GLOBALS.media.retry_failed(url);
     }
 
     pub fn has_media_loading_failed(&self, url_string: &str) -> Option<String> {

--- a/gossip-bin/src/ui/people/person.rs
+++ b/gossip-bin/src/ui/people/person.rs
@@ -423,6 +423,7 @@ fn content(app: &mut GossipUi, ctx: &Context, ui: &mut Ui, pubkey: PublicKey, pe
                                     );
                                     crate::ui::widgets::break_anywhere_hyperlink_to(
                                         ui,
+                                        app,
                                         "NIP-17",
                                         "https://github.com/nostr-protocol/nips/blob/master/17.md",
                                     );

--- a/gossip-bin/src/ui/theme/test_page.rs
+++ b/gossip-bin/src/ui/theme/test_page.rs
@@ -190,6 +190,7 @@ fn inner(app: &mut GossipUi, ui: &mut Ui, background: Background) {
             ui.label(RichText::new("•").color(Color32::from_gray(128)));
             crate::ui::widgets::break_anywhere_hyperlink_to(
                 ui,
+                app,
                 "https://hyperlink.example.com",
                 "https://hyperlink.example.com",
             );

--- a/gossip-bin/src/ui/widgets/link_context_menu.rs
+++ b/gossip-bin/src/ui/widgets/link_context_menu.rs
@@ -37,7 +37,10 @@ fn draw_reload_media(ui: &mut Ui, app: &mut GossipUi, url: Url) {
             .on_hover_text(error)
             .clicked()
         {
-            app.retry_media(&url);
+            // FIXME: if the user clicks to retry loading and the loading fails
+            // again the blurhash (if it exists) of the image will
+            // flash for a frame and diseppear, what an annoying effect.
+            app.retry_media(url);
         }
     }
 }

--- a/gossip-bin/src/ui/widgets/link_context_menu.rs
+++ b/gossip-bin/src/ui/widgets/link_context_menu.rs
@@ -1,0 +1,62 @@
+use crate::ui::GossipUi;
+use egui_winit::egui::{self, Ui};
+use gossip_lib::GLOBALS;
+use nostr_types::Url;
+
+fn draw_open_and_copy(ui: &mut Ui, url_string: String) {
+    if ui.button("Open in browser").clicked() {
+        let modifiers = ui.ctx().input(|i| i.modifiers);
+        ui.ctx().output_mut(|o| {
+            o.open_url = Some(egui::output::OpenUrl {
+                url: url_string.clone(),
+                new_tab: modifiers.any(),
+            });
+        });
+        ui.close_menu();
+        GLOBALS
+            .status_queue
+            .write()
+            .write("Opening in browser...".to_owned());
+    }
+
+    if ui.button("Copy URL").clicked() {
+        ui.output_mut(|o| o.copied_text = url_string.clone());
+        ui.close_menu();
+        GLOBALS
+            .status_queue
+            .write()
+            .write("Link copied to clipboard!".to_owned());
+    }
+}
+
+fn draw_reload_media(ui: &mut Ui, app: &mut GossipUi, url: Url) {
+    let url_string = url.to_string();
+    if let Some(error) = app.has_media_loading_failed(url_string.as_str()) {
+        if ui
+            .button("Retry loading ...")
+            .on_hover_text(error)
+            .clicked()
+        {
+            app.retry_media(&url);
+        }
+    }
+}
+
+pub(in crate::ui) fn show_link_context(ui: &mut Ui, app: &mut GossipUi, url_string: String) {
+    draw_open_and_copy(ui, url_string);
+
+    if app.is_scrolling() {
+        ui.close_menu();
+    }
+}
+
+pub(in crate::ui) fn show_media_link_context(ui: &mut Ui, app: &mut GossipUi, url: Url) {
+    draw_open_and_copy(ui, url.to_string());
+    draw_reload_media(ui, app, url);
+
+    // This is at the end because if the menu is closed while empty,
+    // the next time it opens, it will have a width that is too small.
+    if app.is_scrolling() {
+        ui.close_menu();
+    }
+}

--- a/gossip-bin/src/ui/widgets/mod.rs
+++ b/gossip-bin/src/ui/widgets/mod.rs
@@ -9,6 +9,9 @@ pub use button::Button;
 mod contact_search;
 pub(super) use contact_search::{capture_keyboard_for_search, show_contact_search};
 
+mod link_context_menu;
+pub(super) use link_context_menu::{show_link_context, show_media_link_context};
+
 mod copy_button;
 pub(crate) mod list_entry;
 pub use copy_button::{CopyButton, COPY_SYMBOL_SIZE};
@@ -238,14 +241,22 @@ pub fn clickable_label(ui: &mut Ui, enabled: bool, text: impl Into<WidgetText>) 
     ui.add_enabled(enabled, label)
 }
 
-pub fn break_anywhere_hyperlink_to(ui: &mut Ui, text: impl Into<WidgetText>, url: impl ToString) {
+pub fn break_anywhere_hyperlink_to(
+    ui: &mut Ui,
+    app: &mut GossipUi,
+    text: impl Into<WidgetText>,
+    url: impl ToString,
+) {
     let mut job = text.into().into_layout_job(
         ui.style(),
         FontSelection::Default,
         ui.layout().vertical_align(),
     );
     job.wrap.break_anywhere = true;
-    ui.hyperlink_to(job, url);
+    let url_string = url.to_string();
+    ui.hyperlink_to(job, url).context_menu(|ui| {
+        show_link_context(ui, app, url_string);
+    });
 }
 
 pub fn options_menu_button(ui: &mut Ui, theme: &Theme, assets: &Assets) -> Response {

--- a/gossip-lib/src/media.rs
+++ b/gossip-lib/src/media.rs
@@ -79,8 +79,9 @@ impl Media {
     }
 
     /// Retry a failed Url
-    pub fn retry_failed(&self, unchecked_url: &UncheckedUrl) {
-        self.failed_media.remove(unchecked_url);
+    pub fn retry_failed(&self, url: Url) {
+        GLOBALS.fetcher.clear_for_retry(url.clone());
+        self.failed_media.remove(&url.to_unchecked_url());
     }
 
     /// Get an image by Url


### PR DESCRIPTION
Related issue: #878

While doing this I discovered that the "Retry loading" button on media links was not working.