### PR TITLE
fix: suppress console on windows release builds

### DIFF
--- a/gossip-bin/src/main.rs
+++ b/gossip-bin/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(debug_assertions), windows_subsystem = "console")]
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::collapsible_else_if)]
 // TEMPORARILY


### PR DESCRIPTION
I installed gossip on my Windows 11 machine using the msi installer and noticed that when I opened it it would also open a terminal window to log events. I checked the codebase, and compared it against my own egui app's codebase, and found that the macro that controls this behavior was set differently. When I changed it and re-compiled in release mode, the terminal window no longer appeared.

It is a simple one-line change.
```diff
- #![cfg_attr(not(debug_assertions), windows_subsystem = "console")]
+ #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
```