### PR TITLE
feat: Namecoin NIP-05 identity resolution via ElectrumX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,6 +2508,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "socks",
  "speedy",
  "tempdir",
  "textnonce",
@@ -5875,6 +5876,17 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,7 @@ dependencies = [
  "mime_guess",
  "normpath",
  "nostr-types",
+ "once_cell",
  "parking_lot",
  "paste",
  "rand 0.8.5",
@@ -2502,6 +2503,7 @@ dependencies = [
  "reqwest",
  "resvg 0.43.0",
  "rhai",
+ "rustls",
  "sdl2",
  "serde",
  "serde_json",
@@ -5371,6 +5373,7 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/gossip-bin/src/ui/mod.rs
+++ b/gossip-bin/src/ui/mod.rs
@@ -556,6 +556,11 @@ struct GossipUi {
     search_note_height: HashMap<Id, f32>,
     search_person_height: HashMap<PublicKey, f32>,
 
+    // Namecoin (.bit / d/ / id/) search resolution state
+    pub(super) namecoin_search_state:
+        std::sync::Arc<std::sync::RwLock<search::NamecoinSearchState>>,
+    pub(super) namecoin_last_query: Option<String>,
+
     // Collapsed threads
     collapsed: Vec<Id>,
 
@@ -828,6 +833,10 @@ impl GossipUi {
             nostr_connect_relay2: "".to_owned(),
             search_note_height: HashMap::new(),
             search_person_height: HashMap::new(),
+            namecoin_search_state: std::sync::Arc::new(std::sync::RwLock::new(
+                search::NamecoinSearchState::Idle,
+            )),
+            namecoin_last_query: None,
             collapsed: vec![],
             opened: HashSet::new(),
             visible_note_ids: vec![],

--- a/gossip-bin/src/ui/search.rs
+++ b/gossip-bin/src/ui/search.rs
@@ -3,9 +3,22 @@ use eframe::{egui, Frame};
 use egui::widgets::Button;
 use egui::{Context, Label, RichText, Sense, Ui};
 use gossip_lib::comms::ToOverlordMessage;
+use gossip_lib::namecoin::{NamecoinLookupError, NAMECOIN_RESOLVER};
 use gossip_lib::{FeedKind, Person, PersonTable, Relay, Table, GLOBALS};
-use nostr_types::Event;
+use nostr_types::{Event, PublicKey};
 use std::sync::atomic::Ordering;
+
+/// State of the Namecoin-based search path, independent of the existing
+/// local/relay search flows.
+#[derive(Debug, Clone)]
+pub(crate) enum NamecoinSearchState {
+    Idle,
+    Loading,
+    Resolved { pubkey: PublicKey, name: String },
+    NotFound,
+    Expired,
+    Unreachable(String),
+}
 
 pub(super) fn update(
     app: &mut GossipUi,
@@ -76,7 +89,13 @@ pub(super) fn update(
                 .to_overlord
                 .send(ToOverlordMessage::SearchRelays(app.search.clone()));
         }
+
+        // Parallel Namecoin resolution if the query looks Namecoin-y.
+        maybe_trigger_namecoin(app);
     }
+
+    // Render any Namecoin resolution status under the search bar.
+    render_namecoin_state(app, ctx, ui);
 
     ui.add_space(12.0);
     ui.separator();
@@ -201,6 +220,132 @@ fn render_searched_note_maybe_fake(
         ui.add_space(height);
     } else {
         render_searched_note(app, ctx, ui, event);
+    }
+}
+
+/// Spawn a background Namecoin resolution if the current search query looks
+/// like a Namecoin identifier and we haven't already resolved it.
+fn maybe_trigger_namecoin(app: &mut GossipUi) {
+    let query = app.search.trim().to_string();
+    if query.is_empty() || !NAMECOIN_RESOLVER.is_namecoin_identifier_static(&query) {
+        // Reset state if user cleared / changed to a non-namecoin query
+        if app.namecoin_last_query.is_some() {
+            *app.namecoin_search_state.write().unwrap() = NamecoinSearchState::Idle;
+            app.namecoin_last_query = None;
+        }
+        return;
+    }
+
+    // Avoid re-spawning for the same query.
+    if app.namecoin_last_query.as_deref() == Some(query.as_str()) {
+        let state = app.namecoin_search_state.read().unwrap();
+        if !matches!(*state, NamecoinSearchState::Idle) {
+            return;
+        }
+    }
+
+    app.namecoin_last_query = Some(query.clone());
+    *app.namecoin_search_state.write().unwrap() = NamecoinSearchState::Loading;
+
+    let state_handle = app.namecoin_search_state.clone();
+    GLOBALS.runtime.spawn(async move {
+        let result = NAMECOIN_RESOLVER.resolve(&query).await;
+        let new_state = match result {
+            Ok(r) => NamecoinSearchState::Resolved {
+                pubkey: r.pubkey,
+                name: r.identifier.name,
+            },
+            Err(NamecoinLookupError::NameNotFound) => NamecoinSearchState::NotFound,
+            Err(NamecoinLookupError::NameExpired) => NamecoinSearchState::Expired,
+            Err(NamecoinLookupError::ServersUnreachable(s)) => {
+                NamecoinSearchState::Unreachable(s)
+            }
+            Err(NamecoinLookupError::Parse(s)) => NamecoinSearchState::Unreachable(s),
+        };
+        *state_handle.write().unwrap() = new_state;
+    });
+}
+
+/// Render the Namecoin search status line directly under the search bar.
+fn render_namecoin_state(app: &mut GossipUi, ctx: &Context, ui: &mut Ui) {
+    let state = { app.namecoin_search_state.read().unwrap().clone() };
+    match state {
+        NamecoinSearchState::Idle => {}
+        NamecoinSearchState::Loading => {
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                ui.spinner();
+                ui.label("Resolving via Namecoin blockchain…");
+            });
+            // Keep repainting while we're waiting so the state flip shows up
+            // without requiring user input.
+            ctx.request_repaint();
+        }
+        NamecoinSearchState::Resolved { pubkey, name } => {
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new(format!("🔗 Namecoin ({name})"))
+                        .color(egui::Color32::from_rgb(80, 170, 80)),
+                );
+                // Try to get a full Person record if we have one, otherwise
+                // fall back to a plain clickable pubkey label.
+                let maybe_person = PersonTable::read_record(pubkey, None).ok().flatten();
+                if let Some(person) = maybe_person {
+                    let label_text = gossip_lib::names::pubkey_short(&person.pubkey);
+                    if ui
+                        .add(Label::new(RichText::new(label_text).strong()).sense(Sense::click()))
+                        .clicked()
+                    {
+                        app.set_page(ctx, Page::Person(person.pubkey));
+                    }
+                    GossipUi::render_person_name_line(app, ui, &person, false);
+                } else {
+                    let short = gossip_lib::names::pubkey_short(&pubkey);
+                    if ui
+                        .add(Label::new(RichText::new(short).strong()).sense(Sense::click()))
+                        .clicked()
+                    {
+                        app.set_page(ctx, Page::Person(pubkey));
+                    }
+                }
+            });
+        }
+        NamecoinSearchState::NotFound => {
+            ui.add_space(6.0);
+            ui.label(
+                RichText::new("Namecoin: name not found on-chain")
+                    .color(egui::Color32::from_rgb(200, 120, 120)),
+            );
+        }
+        NamecoinSearchState::Expired => {
+            ui.add_space(6.0);
+            ui.label(
+                RichText::new("Namecoin: name has expired")
+                    .color(egui::Color32::from_rgb(200, 120, 120)),
+            );
+        }
+        NamecoinSearchState::Unreachable(s) => {
+            ui.add_space(6.0);
+            ui.label(
+                RichText::new(format!("Namecoin: unreachable — {s}"))
+                    .color(egui::Color32::from_rgb(200, 120, 120)),
+            );
+        }
+    }
+}
+
+/// Helper so we don't have to expose the internal `NamecoinIdentifier` type.
+/// (The static `NAMECOIN_RESOLVER` is a `NamecoinResolver`, which has the
+/// associated fn `is_namecoin_identifier`; but it's not a method on the
+/// value. We wrap it here for ergonomics.)
+trait NamecoinResolverExt {
+    fn is_namecoin_identifier_static(&self, s: &str) -> bool;
+}
+
+impl NamecoinResolverExt for gossip_lib::namecoin::NamecoinResolver {
+    fn is_namecoin_identifier_static(&self, s: &str) -> bool {
+        gossip_lib::namecoin::NamecoinResolver::is_namecoin_identifier(s)
     }
 }
 

--- a/gossip-lib/Cargo.toml
+++ b/gossip-lib/Cargo.toml
@@ -76,6 +76,7 @@ sdl2 = { version = "0.37", features = ["bundled"], optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"
+socks = "0.3"
 speedy = { workspace = true }
 tempdir = "0.3"
 textnonce = "1"

--- a/gossip-lib/Cargo.toml
+++ b/gossip-lib/Cargo.toml
@@ -63,8 +63,10 @@ memmap2 = "0.9"
 mime = "0.3"
 mime_guess = "2"
 nostr-types = { workspace = true }
+once_cell = "1"
 parking_lot = { version = "0.12", features = [ "arc_lock", "send_guard" ] }
 paste = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "logging", "ring"] }
 rand = "0.8"
 regex = "1.10"
 reqwest = { version = "0.12", default-features=false, features = ["brotli", "deflate", "gzip", "json", "stream"] }

--- a/gossip-lib/src/lib.rs
+++ b/gossip-lib/src/lib.rs
@@ -107,6 +107,9 @@ pub use media::{media_url_mimetype, Media, MediaLoadingResult};
 mod minion;
 
 mod misc;
+
+/// Namecoin NIP-05 resolution via ElectrumX
+pub mod namecoin;
 pub use misc::{Freshness, Private, ZapState};
 
 /// Rendering various names of users

--- a/gossip-lib/src/namecoin/cache.rs
+++ b/gossip-lib/src/namecoin/cache.rs
@@ -1,0 +1,142 @@
+//! LRU cache with TTL for Namecoin name lookups.
+//!
+//! Caches resolved pubkeys to avoid repeated ElectrumX queries.
+//! Entries expire after 1 hour.
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use nostr_types::PublicKey;
+
+use super::NamecoinLookupError;
+
+const CACHE_TTL: Duration = Duration::from_secs(3600); // 1 hour
+const MAX_CACHE_SIZE: usize = 256;
+
+#[derive(Debug, Clone)]
+pub struct CacheEntry {
+    pub pubkey: Option<PublicKey>,
+    pub error: Option<NamecoinLookupError>,
+    pub inserted_at: Instant,
+}
+
+impl CacheEntry {
+    pub fn is_expired(&self) -> bool {
+        self.inserted_at.elapsed() >= CACHE_TTL
+    }
+}
+
+pub struct NamecoinLookupCache {
+    entries: HashMap<String, CacheEntry>,
+    /// Insertion order for LRU eviction (front = oldest)
+    insertion_order: VecDeque<String>,
+}
+
+impl Default for NamecoinLookupCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NamecoinLookupCache {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            insertion_order: VecDeque::new(),
+        }
+    }
+
+    /// Get a cached entry if it exists and hasn't expired.
+    pub fn get(&self, key: &str) -> Option<CacheEntry> {
+        self.entries
+            .get(key)
+            .filter(|entry| !entry.is_expired())
+            .cloned()
+    }
+
+    /// Insert or update a cache entry.
+    ///
+    /// Automatically evicts expired entries and the oldest entry when at
+    /// capacity. Uses `VecDeque` for O(1) front eviction.
+    pub fn insert(&mut self, key: String, result: Result<PublicKey, NamecoinLookupError>) {
+        // Evict expired entries first to reclaim space
+        self.evict_expired();
+
+        // Evict oldest if still at capacity
+        while self.entries.len() >= MAX_CACHE_SIZE {
+            if let Some(oldest) = self.insertion_order.pop_front() {
+                self.entries.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+
+        // Remove old entry from insertion order if updating
+        self.insertion_order.retain(|k| k != &key);
+
+        let (pubkey, error) = match result {
+            Ok(pk) => (Some(pk), None),
+            Err(e) => (None, Some(e)),
+        };
+
+        self.entries.insert(
+            key.clone(),
+            CacheEntry {
+                pubkey,
+                error,
+                inserted_at: Instant::now(),
+            },
+        );
+        self.insertion_order.push_back(key);
+    }
+
+    /// Remove expired entries from both `entries` and `insertion_order`.
+    pub fn evict_expired(&mut self) {
+        self.entries.retain(|_, entry| !entry.is_expired());
+        self.insertion_order
+            .retain(|key| self.entries.contains_key(key));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_pubkey() -> PublicKey {
+        // 32 bytes of 0x01 — a syntactically valid secp256k1 x-only pubkey is
+        // not required for cache tests, but PublicKey::try_from_hex_string
+        // won't accept arbitrary bytes. Use a known-good hex constant.
+        let hex = "0000000000000000000000000000000000000000000000000000000000000001";
+        PublicKey::try_from_hex_string(hex, false).unwrap()
+    }
+
+    #[test]
+    fn test_cache_insert_and_get() {
+        let mut cache = NamecoinLookupCache::new();
+        let pk = fake_pubkey();
+
+        cache.insert("d/test".to_string(), Ok(pk));
+
+        let entry = cache.get("d/test");
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().pubkey, Some(pk));
+    }
+
+    #[test]
+    fn test_cache_miss() {
+        let cache = NamecoinLookupCache::new();
+        assert!(cache.get("d/nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_cache_negative_result() {
+        let mut cache = NamecoinLookupCache::new();
+        cache.insert(
+            "d/expired".to_string(),
+            Err(NamecoinLookupError::NameNotFound),
+        );
+
+        let entry = cache.get("d/expired");
+        assert!(entry.is_some());
+        assert!(entry.unwrap().pubkey.is_none());
+    }
+}

--- a/gossip-lib/src/namecoin/electrumx.rs
+++ b/gossip-lib/src/namecoin/electrumx.rs
@@ -238,23 +238,69 @@ fn rpc_call(
         .ok_or_else(|| ElectrumxError::RpcError("Missing result field".to_string()))
 }
 
-/// Connect to an ElectrumX server via TLS.
+/// Read the SOCKS5 proxy setting. Empty string = no proxy (direct TCP).
+///
+/// Uses `catch_unwind` because `GLOBALS.db()` panics if storage isn't initialized
+/// (e.g. in unit tests or very early boot). Empty string falls back to direct TCP,
+/// matching the pre-SOCKS5 behaviour.
+fn read_socks5_proxy_setting() -> String {
+    match std::panic::catch_unwind(|| {
+        crate::globals::GLOBALS
+            .db()
+            .read_setting_namecoin_socks5_proxy()
+    }) {
+        Ok(s) => s,
+        Err(_) => String::new(),
+    }
+}
+
+/// Connect to an ElectrumX server via TLS, optionally through a SOCKS5 proxy.
 fn connect_tls(
     server: &ElectrumxServer,
 ) -> Result<rustls::StreamOwned<rustls::ClientConnection, TcpStream>, ElectrumxError> {
     use std::net::ToSocketAddrs;
 
-    let addr_str = format!("{}:{}", server.host, server.port);
-    let addrs: Vec<_> = addr_str
-        .to_socket_addrs()
-        .map_err(ElectrumxError::Io)?
-        .collect();
+    let proxy = read_socks5_proxy_setting();
 
-    let first = addrs
-        .first()
-        .ok_or_else(|| ElectrumxError::Io(std::io::Error::other("DNS resolution failed")))?;
+    if !proxy.is_empty() {
+        tracing::info!(
+            "electrumx: dialing {}:{} via SOCKS5 proxy {}",
+            server.host,
+            server.port,
+            proxy
+        );
+    } else {
+        tracing::info!("electrumx: dialing {}:{} direct", server.host, server.port);
+    }
 
-    let tcp = TcpStream::connect_timeout(first, Duration::from_secs(10))?;
+    let tcp = if proxy.is_empty() {
+        let addr_str = format!("{}:{}", server.host, server.port);
+        let addrs: Vec<_> = addr_str
+            .to_socket_addrs()
+            .map_err(ElectrumxError::Io)?
+            .collect();
+
+        let first = addrs.first().ok_or_else(|| {
+            ElectrumxError::Io(std::io::Error::other("DNS resolution failed"))
+        })?;
+
+        TcpStream::connect_timeout(first, Duration::from_secs(10))?
+    } else {
+        // Route through SOCKS5. DNS resolution happens at the proxy, which is
+        // important for Tor (prevents local DNS leaks).
+        let target = (server.host.as_str(), server.port);
+        let socks_stream = socks::Socks5Stream::connect(proxy.as_str(), target).map_err(|e| {
+            tracing::warn!(
+                "electrumx: SOCKS5 dial to {} via {} failed: {}",
+                server.host,
+                proxy,
+                e
+            );
+            ElectrumxError::Io(e)
+        })?;
+        socks_stream.into_inner()
+    };
+
     tcp.set_read_timeout(Some(Duration::from_secs(15)))?;
     tcp.set_write_timeout(Some(Duration::from_secs(10)))?;
 

--- a/gossip-lib/src/namecoin/electrumx.rs
+++ b/gossip-lib/src/namecoin/electrumx.rs
@@ -1,0 +1,655 @@
+//! ElectrumX TCP/TLS client for Namecoin name lookups.
+//!
+//! Communicates with ElectrumX-NMC servers using JSON-RPC over TLS.
+//! Uses the scripthash-based approach described in the Electrum protocol:
+//! 1. Build canonical name index script
+//! 2. Compute Electrum-style scripthash (reversed SHA-256)
+//! 3. Query `blockchain.scripthash.get_history` for tx history
+//! 4. Fetch and parse NAME_UPDATE from the latest transaction
+//! 5. Check name expiry via `blockchain.headers.subscribe`
+use sha2::{Digest, Sha256};
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// An ElectrumX server endpoint.
+#[derive(Debug, Clone)]
+pub struct ElectrumxServer {
+    pub host: String,
+    pub port: u16,
+}
+
+pub fn default_servers() -> Vec<ElectrumxServer> {
+    vec![
+        ElectrumxServer {
+            host: "electrumx.testls.space".to_string(),
+            port: 50002,
+        },
+        ElectrumxServer {
+            host: "nmc2.bitcoins.sk".to_string(),
+            port: 57002,
+        },
+        ElectrumxServer {
+            host: "46.229.238.187".to_string(),
+            port: 57002,
+        },
+    ]
+}
+
+/// Result from a name lookup.
+#[derive(Debug, Clone)]
+pub struct NameShowResult {
+    /// The raw JSON value stored on-chain.
+    pub value: String,
+    /// Block height of the last NAME_UPDATE.
+    pub height: i64,
+    /// Blocks until expiry (None if not computed).
+    pub expires_in: Option<i64>,
+}
+
+/// Namecoin names expire 36,000 blocks (~250 days) after their last update.
+const NAME_EXPIRY_BLOCKS: i64 = 36_000;
+
+/// Errors from ElectrumX operations.
+#[derive(Debug)]
+pub enum ElectrumxError {
+    Io(std::io::Error),
+    Tls(String),
+    Json(serde_json::Error),
+    RpcError(String),
+    NameNotFound,
+    NameExpired,
+    NoServersAvailable,
+    ParseError(String),
+    Timeout,
+}
+
+impl std::fmt::Display for ElectrumxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "IO error: {e}"),
+            Self::Tls(e) => write!(f, "TLS error: {e}"),
+            Self::Json(e) => write!(f, "JSON error: {e}"),
+            Self::RpcError(e) => write!(f, "RPC error: {e}"),
+            Self::NameNotFound => write!(f, "Name not found"),
+            Self::NameExpired => write!(f, "Name expired"),
+            Self::NoServersAvailable => write!(f, "No ElectrumX servers available"),
+            Self::ParseError(e) => write!(f, "Parse error: {e}"),
+            Self::Timeout => write!(f, "Connection timeout"),
+        }
+    }
+}
+
+impl std::error::Error for ElectrumxError {}
+
+impl From<std::io::Error> for ElectrumxError {
+    fn from(e: std::io::Error) -> Self {
+        if e.kind() == std::io::ErrorKind::TimedOut {
+            Self::Timeout
+        } else {
+            Self::Io(e)
+        }
+    }
+}
+
+impl From<serde_json::Error> for ElectrumxError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
+    }
+}
+
+/// A TLS certificate verifier that accepts self-signed certificates.
+/// ElectrumX-NMC servers commonly use self-signed TLS certificates.
+#[derive(Debug)]
+struct AcceptAnyCert;
+
+impl rustls::client::danger::ServerCertVerifier for AcceptAnyCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ED448,
+        ]
+    }
+}
+
+/// Build the canonical name index script for a Namecoin name.
+///
+/// ElectrumX-NMC indexes names using a canonical script derived from the name.
+/// The format is:
+///   `OP_NAME_UPDATE + push(name) + push(empty) + OP_2DROP + OP_DROP + OP_RETURN`
+fn build_name_script(name: &str) -> Vec<u8> {
+    let name_bytes = name.as_bytes();
+    let mut script = Vec::with_capacity(6 + name_bytes.len());
+
+    // OP_NAME_UPDATE = OP_3 = 0x53 in Namecoin
+    script.push(0x53);
+
+    // push_data(name_bytes)
+    push_data(&mut script, name_bytes);
+
+    // push_data(empty) — canonical index script uses empty value
+    push_data(&mut script, &[]);
+
+    // OP_2DROP OP_DROP OP_RETURN
+    script.push(0x6d); // OP_2DROP
+    script.push(0x75); // OP_DROP
+    script.push(0x6a); // OP_RETURN
+
+    script
+}
+
+/// Bitcoin-style push data encoding.
+fn push_data(script: &mut Vec<u8>, data: &[u8]) {
+    let len = data.len();
+    if len < 0x4c {
+        script.push(len as u8);
+    } else if len <= 0xff {
+        script.push(0x4c); // OP_PUSHDATA1
+        script.push(len as u8);
+    } else {
+        script.push(0x4d); // OP_PUSHDATA2
+        script.extend_from_slice(&(len as u16).to_le_bytes());
+    }
+    script.extend_from_slice(data);
+}
+
+/// Compute the Electrum-style scripthash: reversed SHA-256 of the script, as hex.
+fn compute_scripthash(name: &str) -> String {
+    let script = build_name_script(name);
+    let hash = Sha256::digest(&script);
+    let mut reversed = hash.to_vec();
+    reversed.reverse();
+    hex::encode(reversed)
+}
+
+/// Perform a JSON-RPC call over a buffered TLS stream and return the result.
+fn rpc_call(
+    reader: &mut BufReader<rustls::StreamOwned<rustls::ClientConnection, TcpStream>>,
+    method: &str,
+    params: &serde_json::Value,
+    id: u64,
+) -> Result<serde_json::Value, ElectrumxError> {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": id,
+    });
+
+    let mut request_str = serde_json::to_string(&request)?;
+    request_str.push('\n');
+    reader.get_mut().write_all(request_str.as_bytes())?;
+    reader.get_mut().flush()?;
+
+    // Read response line (JSON-RPC uses newline-delimited messages)
+    let mut response_line = String::new();
+    reader.read_line(&mut response_line)?;
+
+    let response: serde_json::Value = serde_json::from_str(&response_line)?;
+
+    if let Some(error) = response.get("error") {
+        if !error.is_null() {
+            return Err(ElectrumxError::RpcError(error.to_string()));
+        }
+    }
+
+    response
+        .get("result")
+        .cloned()
+        .ok_or_else(|| ElectrumxError::RpcError("Missing result field".to_string()))
+}
+
+/// Connect to an ElectrumX server via TLS.
+fn connect_tls(
+    server: &ElectrumxServer,
+) -> Result<rustls::StreamOwned<rustls::ClientConnection, TcpStream>, ElectrumxError> {
+    use std::net::ToSocketAddrs;
+
+    let addr_str = format!("{}:{}", server.host, server.port);
+    let addrs: Vec<_> = addr_str
+        .to_socket_addrs()
+        .map_err(ElectrumxError::Io)?
+        .collect();
+
+    let first = addrs
+        .first()
+        .ok_or_else(|| ElectrumxError::Io(std::io::Error::other("DNS resolution failed")))?;
+
+    let tcp = TcpStream::connect_timeout(first, Duration::from_secs(10))?;
+    tcp.set_read_timeout(Some(Duration::from_secs(15)))?;
+    tcp.set_write_timeout(Some(Duration::from_secs(10)))?;
+
+    // Build TLS config accepting self-signed certificates
+    let config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAnyCert))
+        .with_no_client_auth();
+
+    // Use the hostname for SNI, falling back to a dummy name for IP addresses
+    let server_name: rustls::pki_types::ServerName<'static> = server
+        .host
+        .clone()
+        .try_into()
+        .unwrap_or_else(|_| "electrumx".to_string().try_into().unwrap());
+
+    let tls_conn = rustls::ClientConnection::new(Arc::new(config), server_name)
+        .map_err(|e| ElectrumxError::Tls(e.to_string()))?;
+
+    Ok(rustls::StreamOwned::new(tls_conn, tcp))
+}
+
+/// Parse a NAME_UPDATE value from a raw transaction output script.
+fn parse_name_value_from_script(script_hex: &str) -> Option<String> {
+    let script = hex::decode(script_hex).ok()?;
+
+    if script.is_empty() {
+        return None;
+    }
+
+    // Check for OP_NAME_UPDATE (0x53) at the start
+    if script[0] != 0x53 {
+        return None;
+    }
+
+    let mut pos = 1;
+
+    // Skip first push data (the name)
+    pos = skip_push_data(&script, pos)?;
+
+    // Read second push data (the value)
+    let (value_bytes, _) = read_push_data(&script, pos)?;
+
+    String::from_utf8(value_bytes).ok()
+}
+
+/// Skip over a push data element in a script, returning the new position.
+fn skip_push_data(script: &[u8], pos: usize) -> Option<usize> {
+    if pos >= script.len() {
+        return None;
+    }
+
+    let opcode = script[pos];
+
+    if opcode < 76 {
+        let len = opcode as usize;
+        let end = pos + 1 + len;
+        if end > script.len() {
+            return None;
+        }
+        Some(end)
+    } else if opcode == 0x4c {
+        if pos + 1 >= script.len() {
+            return None;
+        }
+        let len = script[pos + 1] as usize;
+        let end = pos + 2 + len;
+        if end > script.len() {
+            return None;
+        }
+        Some(end)
+    } else if opcode == 0x4d {
+        if pos + 2 >= script.len() {
+            return None;
+        }
+        let len = u16::from_le_bytes([script[pos + 1], script[pos + 2]]) as usize;
+        let end = pos + 3 + len;
+        if end > script.len() {
+            return None;
+        }
+        Some(end)
+    } else {
+        None
+    }
+}
+
+/// Read push data from a script, returning (data, new_position).
+fn read_push_data(script: &[u8], pos: usize) -> Option<(Vec<u8>, usize)> {
+    if pos >= script.len() {
+        return None;
+    }
+
+    let opcode = script[pos];
+
+    if opcode < 76 {
+        let len = opcode as usize;
+        let start = pos + 1;
+        let end = start + len;
+        if end > script.len() {
+            return None;
+        }
+        Some((script[start..end].to_vec(), end))
+    } else if opcode == 0x4c {
+        if pos + 1 >= script.len() {
+            return None;
+        }
+        let len = script[pos + 1] as usize;
+        let start = pos + 2;
+        let end = start + len;
+        if end > script.len() {
+            return None;
+        }
+        Some((script[start..end].to_vec(), end))
+    } else if opcode == 0x4d {
+        if pos + 2 >= script.len() {
+            return None;
+        }
+        let len = u16::from_le_bytes([script[pos + 1], script[pos + 2]]) as usize;
+        let start = pos + 3;
+        let end = start + len;
+        if end > script.len() {
+            return None;
+        }
+        Some((script[start..end].to_vec(), end))
+    } else {
+        None
+    }
+}
+
+/// Parse the raw hex transaction to find NAME_UPDATE outputs and extract the value.
+fn extract_name_value_from_raw_tx(raw_hex: &str) -> Option<String> {
+    let raw = hex::decode(raw_hex).ok()?;
+
+    // Minimal Bitcoin transaction parsing to find output scripts
+    let mut pos = 4; // skip version
+
+    // Check for segwit marker
+    let has_witness = pos + 1 < raw.len() && raw[pos] == 0x00 && raw[pos + 1] != 0x00;
+    if has_witness {
+        pos += 2; // skip marker + flag
+    }
+
+    // Skip inputs
+    let (vin_count, new_pos) = read_varint(&raw, pos)?;
+    pos = new_pos;
+
+    for _ in 0..vin_count {
+        pos += 32; // txid
+        pos += 4; // vout index
+        let (script_len, new_pos) = read_varint(&raw, pos)?;
+        pos = new_pos + script_len as usize; // skip script
+        pos += 4; // sequence
+        if pos > raw.len() {
+            return None;
+        }
+    }
+
+    // Parse outputs - look for NAME_UPDATE
+    let (vout_count, new_pos) = read_varint(&raw, pos)?;
+    pos = new_pos;
+
+    for _ in 0..vout_count {
+        pos += 8; // value (satoshis)
+        let (script_len, new_pos) = read_varint(&raw, pos)?;
+        pos = new_pos;
+
+        if pos + script_len as usize > raw.len() {
+            return None;
+        }
+
+        let script = &raw[pos..pos + script_len as usize];
+
+        // Check if this output starts with OP_NAME_UPDATE (0x53)
+        if !script.is_empty() && script[0] == 0x53 {
+            let script_hex = hex::encode(script);
+            if let Some(value) = parse_name_value_from_script(&script_hex) {
+                return Some(value);
+            }
+        }
+
+        pos += script_len as usize;
+    }
+
+    None
+}
+
+/// Read a Bitcoin-style varint.
+fn read_varint(data: &[u8], pos: usize) -> Option<(u64, usize)> {
+    if pos >= data.len() {
+        return None;
+    }
+
+    let first = data[pos];
+    match first {
+        0..=0xfc => Some((first as u64, pos + 1)),
+        0xfd => {
+            if pos + 2 >= data.len() {
+                return None;
+            }
+            let val = u16::from_le_bytes([data[pos + 1], data[pos + 2]]) as u64;
+            Some((val, pos + 3))
+        }
+        0xfe => {
+            if pos + 4 >= data.len() {
+                return None;
+            }
+            let val = u32::from_le_bytes([
+                data[pos + 1],
+                data[pos + 2],
+                data[pos + 3],
+                data[pos + 4],
+            ]) as u64;
+            Some((val, pos + 5))
+        }
+        0xff => {
+            if pos + 8 >= data.len() {
+                return None;
+            }
+            let val = u64::from_le_bytes([
+                data[pos + 1],
+                data[pos + 2],
+                data[pos + 3],
+                data[pos + 4],
+                data[pos + 5],
+                data[pos + 6],
+                data[pos + 7],
+                data[pos + 8],
+            ]);
+            Some((val, pos + 9))
+        }
+    }
+}
+
+/// Look up a Namecoin name via a single ElectrumX server.
+fn name_show_single(
+    server: &ElectrumxServer,
+    name: &str,
+) -> Result<NameShowResult, ElectrumxError> {
+    let stream = connect_tls(server)?;
+    let mut reader = BufReader::new(stream);
+    let mut rpc_id: u64 = 1;
+
+    let scripthash = compute_scripthash(name);
+
+    let history = rpc_call(
+        &mut reader,
+        "blockchain.scripthash.get_history",
+        &serde_json::json!([scripthash]),
+        rpc_id,
+    )?;
+    rpc_id += 1;
+
+    let history_arr = history.as_array().ok_or(ElectrumxError::NameNotFound)?;
+
+    if history_arr.is_empty() {
+        return Err(ElectrumxError::NameNotFound);
+    }
+
+    // Find the transaction with the highest height (most recent)
+    let latest = history_arr
+        .iter()
+        .max_by_key(|entry| entry.get("height").and_then(|h| h.as_i64()).unwrap_or(0))
+        .ok_or(ElectrumxError::NameNotFound)?;
+
+    let tx_hash = latest
+        .get("tx_hash")
+        .and_then(|h| h.as_str())
+        .ok_or(ElectrumxError::ParseError("missing tx_hash".to_string()))?;
+
+    let tx_height = latest.get("height").and_then(|h| h.as_i64()).unwrap_or(0);
+
+    let raw_tx = rpc_call(
+        &mut reader,
+        "blockchain.transaction.get",
+        &serde_json::json!([tx_hash]),
+        rpc_id,
+    )?;
+    rpc_id += 1;
+
+    let raw_hex = raw_tx
+        .as_str()
+        .ok_or(ElectrumxError::ParseError("tx not a string".to_string()))?;
+
+    let value = extract_name_value_from_raw_tx(raw_hex)
+        .ok_or(ElectrumxError::ParseError("no NAME_UPDATE in tx".to_string()))?;
+
+    let headers_result = rpc_call(
+        &mut reader,
+        "blockchain.headers.subscribe",
+        &serde_json::json!([]),
+        rpc_id,
+    );
+
+    let mut expires_in = None;
+
+    if let Ok(headers) = headers_result {
+        if let Some(current_height) = headers.get("height").and_then(|h| h.as_i64()) {
+            if tx_height > 0 {
+                let blocks_since_update = current_height - tx_height;
+                if blocks_since_update >= NAME_EXPIRY_BLOCKS {
+                    return Err(ElectrumxError::NameExpired);
+                }
+                expires_in = Some(NAME_EXPIRY_BLOCKS - blocks_since_update);
+            }
+        }
+    }
+
+    Ok(NameShowResult {
+        value,
+        height: tx_height,
+        expires_in,
+    })
+}
+
+/// Look up a Namecoin name, trying multiple servers with fallback.
+pub fn name_show(
+    servers: &[ElectrumxServer],
+    name: &str,
+) -> Result<NameShowResult, ElectrumxError> {
+    if servers.is_empty() {
+        return Err(ElectrumxError::NoServersAvailable);
+    }
+
+    let mut last_error = ElectrumxError::NoServersAvailable;
+
+    for server in servers {
+        tracing::debug!(
+            "Trying ElectrumX server {}:{} for name '{}'",
+            server.host,
+            server.port,
+            name
+        );
+
+        match name_show_single(server, name) {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                tracing::warn!(
+                    "ElectrumX server {}:{} failed for '{}': {}",
+                    server.host,
+                    server.port,
+                    name,
+                    e
+                );
+                last_error = e;
+            }
+        }
+    }
+
+    Err(last_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_scripthash() {
+        let hash = compute_scripthash("d/testls");
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_build_name_script() {
+        let script = build_name_script("d/testls");
+        assert_eq!(script[0], 0x53); // OP_NAME_UPDATE
+        assert_eq!(script[1], 8); // push length
+        assert_eq!(&script[2..10], b"d/testls");
+        assert_eq!(script[10], 0x00); // push(empty) — length 0
+        assert_eq!(script[11], 0x6d); // OP_2DROP
+        assert_eq!(script[12], 0x75); // OP_DROP
+        assert_eq!(script[13], 0x6a); // OP_RETURN
+        assert_eq!(script.len(), 14);
+    }
+
+    #[test]
+    fn test_parse_name_value_simple() {
+        let name = b"d/test";
+        let value = b"{\"nostr\":\"abc\"}";
+
+        let mut script = vec![0x53]; // OP_NAME_UPDATE
+        script.push(name.len() as u8);
+        script.extend_from_slice(name);
+        script.push(value.len() as u8);
+        script.extend_from_slice(value);
+
+        let hex = hex::encode(&script);
+        let parsed = parse_name_value_from_script(&hex);
+        assert_eq!(parsed, Some("{\"nostr\":\"abc\"}".to_string()));
+    }
+
+    #[test]
+    fn test_read_varint() {
+        assert_eq!(read_varint(&[0x01], 0), Some((1, 1)));
+        assert_eq!(read_varint(&[0xfc], 0), Some((252, 1)));
+        assert_eq!(read_varint(&[0xfd, 0x00, 0x01], 0), Some((256, 3)));
+    }
+}

--- a/gossip-lib/src/namecoin/identifier.rs
+++ b/gossip-lib/src/namecoin/identifier.rs
@@ -1,0 +1,180 @@
+//! Namecoin identifier parsing and detection.
+//!
+//! Supports the following formats:
+//! - `alice@example.bit` → NIP-05 style, resolves `d/example` for `alice` entry
+//! - `example.bit` → Bare domain, resolves `d/example` for root `_` entry
+//! - `d/example` → Direct domain namespace lookup
+//! - `id/alice` → Direct identity namespace lookup
+
+/// A parsed Namecoin identifier ready for resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamecoinIdentifier {
+    /// The Namecoin name to look up (e.g., `d/testls`, `id/alice`)
+    pub name: String,
+    /// The local part to resolve within the name's JSON value.
+    /// `_` for root lookups, otherwise the user portion.
+    pub local_part: String,
+}
+
+impl NamecoinIdentifier {
+    /// Parse a string into a Namecoin identifier, if it matches any supported format.
+    pub fn parse(input: &str) -> Option<Self> {
+        let input = input.trim();
+        if input.is_empty() {
+            return None;
+        }
+
+        // Format: d/name or id/name (direct namespace)
+        if let Some(name) = input.strip_prefix("d/") {
+            if !name.is_empty() && is_valid_name(name) {
+                return Some(Self {
+                    name: input.to_string(),
+                    local_part: "_".to_string(),
+                });
+            }
+        }
+        if let Some(name) = input.strip_prefix("id/") {
+            if !name.is_empty() && is_valid_name(name) {
+                return Some(Self {
+                    name: input.to_string(),
+                    local_part: "_".to_string(),
+                });
+            }
+        }
+
+        // Format: user@domain.bit or domain.bit
+        if input.ends_with(".bit") {
+            if let Some(at_pos) = input.find('@') {
+                // user@domain.bit
+                let user = &input[..at_pos];
+                let domain = &input[at_pos + 1..];
+                let domain_name = domain.strip_suffix(".bit")?;
+                if !user.is_empty()
+                    && is_valid_local_part(user)
+                    && !domain_name.is_empty()
+                    && is_valid_name(domain_name)
+                {
+                    return Some(Self {
+                        name: format!("d/{domain_name}"),
+                        local_part: user.to_string(),
+                    });
+                }
+            } else {
+                // bare domain.bit
+                let domain_name = input.strip_suffix(".bit")?;
+                if !domain_name.is_empty() && is_valid_name(domain_name) {
+                    return Some(Self {
+                        name: format!("d/{domain_name}"),
+                        local_part: "_".to_string(),
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Returns true if the given string is any form of Namecoin identifier.
+    pub fn is_namecoin_identifier(input: &str) -> bool {
+        Self::parse(input).is_some()
+    }
+
+    /// Returns true if this is a root lookup (local_part == "_").
+    pub fn is_root(&self) -> bool {
+        self.local_part == "_"
+    }
+}
+
+/// Check if a name component is valid (alphanumeric, hyphens, underscores, dots).
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+/// Check if a local part (user portion of `user@domain.bit`) is valid.
+/// Allows alphanumeric characters, hyphens, underscores, and dots.
+fn is_valid_local_part(local: &str) -> bool {
+    !local.is_empty()
+        && local
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_direct_domain() {
+        let id = NamecoinIdentifier::parse("d/testls").unwrap();
+        assert_eq!(id.name, "d/testls");
+        assert_eq!(id.local_part, "_");
+    }
+
+    #[test]
+    fn test_parse_direct_identity() {
+        let id = NamecoinIdentifier::parse("id/alice").unwrap();
+        assert_eq!(id.name, "id/alice");
+        assert_eq!(id.local_part, "_");
+    }
+
+    #[test]
+    fn test_parse_nip05_bit() {
+        let id = NamecoinIdentifier::parse("m@testls.bit").unwrap();
+        assert_eq!(id.name, "d/testls");
+        assert_eq!(id.local_part, "m");
+    }
+
+    #[test]
+    fn test_parse_bare_domain() {
+        let id = NamecoinIdentifier::parse("testls.bit").unwrap();
+        assert_eq!(id.name, "d/testls");
+        assert_eq!(id.local_part, "_");
+    }
+
+    #[test]
+    fn test_is_namecoin_identifier() {
+        assert!(NamecoinIdentifier::is_namecoin_identifier("d/testls"));
+        assert!(NamecoinIdentifier::is_namecoin_identifier("id/alice"));
+        assert!(NamecoinIdentifier::is_namecoin_identifier("testls.bit"));
+        assert!(NamecoinIdentifier::is_namecoin_identifier("m@testls.bit"));
+
+        assert!(!NamecoinIdentifier::is_namecoin_identifier(
+            "user@example.com"
+        ));
+        assert!(!NamecoinIdentifier::is_namecoin_identifier("npub1abc"));
+        assert!(!NamecoinIdentifier::is_namecoin_identifier("hello"));
+        assert!(!NamecoinIdentifier::is_namecoin_identifier(""));
+    }
+
+    #[test]
+    fn test_invalid_names() {
+        assert!(NamecoinIdentifier::parse("d/").is_none());
+        assert!(NamecoinIdentifier::parse("id/").is_none());
+        assert!(NamecoinIdentifier::parse(".bit").is_none());
+        assert!(NamecoinIdentifier::parse("@.bit").is_none());
+    }
+
+    #[test]
+    fn test_invalid_local_part() {
+        // Local part with spaces or special characters should be rejected
+        assert!(NamecoinIdentifier::parse("bad user@testls.bit").is_none());
+        assert!(NamecoinIdentifier::parse("bad!user@testls.bit").is_none());
+        assert!(NamecoinIdentifier::parse("user name@testls.bit").is_none());
+        // Valid local parts should still work
+        assert!(NamecoinIdentifier::parse("valid-user@testls.bit").is_some());
+        assert!(NamecoinIdentifier::parse("user_name@testls.bit").is_some());
+        assert!(NamecoinIdentifier::parse("user.name@testls.bit").is_some());
+    }
+
+    #[test]
+    fn test_root_detection() {
+        let root = NamecoinIdentifier::parse("d/testls").unwrap();
+        assert!(root.is_root());
+
+        let non_root = NamecoinIdentifier::parse("m@testls.bit").unwrap();
+        assert!(!non_root.is_root());
+    }
+}

--- a/gossip-lib/src/namecoin/mod.rs
+++ b/gossip-lib/src/namecoin/mod.rs
@@ -1,0 +1,328 @@
+//! Namecoin NIP-05 resolution via ElectrumX.
+//!
+//! Provides censorship-resistant NIP-05 identity verification using the
+//! Namecoin blockchain. Users can set their `nip05` field to a `.bit` domain
+//! (e.g. `alice@example.bit`) or a direct Namecoin name (`d/example`,
+//! `id/alice`) and gossip will resolve the pubkey mapping via ElectrumX
+//! instead of HTTPS.
+//!
+//! Ported from the notedeck Namecoin module (PR #1314), originally derived
+//! from Amethyst's Namecoin NIP-05 feature.
+
+pub mod cache;
+pub mod electrumx;
+pub mod identifier;
+
+use std::sync::Arc;
+
+use nostr_types::PublicKey;
+use parking_lot::Mutex as PMutex;
+
+use self::cache::NamecoinLookupCache;
+use self::electrumx::{default_servers, ElectrumxServer};
+use self::identifier::NamecoinIdentifier;
+
+/// Why a Namecoin resolution failed.
+#[derive(Debug, Clone)]
+pub enum NamecoinLookupError {
+    /// The name does not exist on the blockchain.
+    NameNotFound,
+    /// The name is past its 36000-block expiry.
+    NameExpired,
+    /// All configured ElectrumX servers were unreachable or errored.
+    ServersUnreachable(String),
+    /// Value parse failure.
+    Parse(String),
+}
+
+impl std::fmt::Display for NamecoinLookupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NameNotFound => write!(f, "Name not found"),
+            Self::NameExpired => write!(f, "Name expired"),
+            Self::ServersUnreachable(s) => write!(f, "Servers unreachable: {s}"),
+            Self::Parse(s) => write!(f, "Parse error: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for NamecoinLookupError {}
+
+/// The resolved Namecoin identity for UI / caller display.
+#[derive(Debug, Clone)]
+pub struct NamecoinResolveResult {
+    pub pubkey: PublicKey,
+    pub identifier: NamecoinIdentifier,
+}
+
+/// High-level resolver. Cheap to clone (internal Arc).
+#[derive(Clone)]
+pub struct NamecoinResolver {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    cache: PMutex<NamecoinLookupCache>,
+    servers: PMutex<Vec<ElectrumxServer>>,
+}
+
+impl Default for NamecoinResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NamecoinResolver {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                cache: PMutex::new(NamecoinLookupCache::new()),
+                servers: PMutex::new(default_servers()),
+            }),
+        }
+    }
+
+    /// Override the ElectrumX server list.
+    pub fn set_servers(&self, servers: Vec<ElectrumxServer>) {
+        *self.inner.servers.lock() = servers;
+    }
+
+    /// Returns true if `input` looks like any supported Namecoin identifier.
+    pub fn is_namecoin_identifier(input: &str) -> bool {
+        NamecoinIdentifier::is_namecoin_identifier(input)
+    }
+
+    /// Resolve a Namecoin identifier to a Nostr pubkey.
+    ///
+    /// Cached lookups return immediately; network lookups are performed on a
+    /// blocking threadpool via `tokio::task::spawn_blocking` so this future
+    /// cooperates with the async runtime.
+    pub async fn resolve(
+        &self,
+        input: &str,
+    ) -> Result<NamecoinResolveResult, NamecoinLookupError> {
+        let Some(identifier) = NamecoinIdentifier::parse(input) else {
+            return Err(NamecoinLookupError::NameNotFound);
+        };
+
+        let cache_key = input.to_string();
+
+        // Check cache first
+        if let Some(entry) = self.inner.cache.lock().get(&cache_key) {
+            if let Some(pk) = entry.pubkey {
+                return Ok(NamecoinResolveResult {
+                    pubkey: pk,
+                    identifier,
+                });
+            }
+            if let Some(err) = entry.error {
+                return Err(err);
+            }
+        }
+
+        let servers = self.inner.servers.lock().clone();
+        let id_for_task = identifier.clone();
+
+        let result = tokio::task::spawn_blocking(move || resolve_identifier(&servers, &id_for_task))
+            .await
+            .map_err(|e| NamecoinLookupError::ServersUnreachable(format!("join: {e}")))?;
+
+        // Cache both success and failure
+        self.inner.cache.lock().insert(cache_key, result.clone());
+
+        result.map(|pubkey| NamecoinResolveResult { pubkey, identifier })
+    }
+
+    /// Verify that a NIP-05 `.bit` address resolves to the given pubkey on-chain.
+    ///
+    /// Returns `Ok(true)` if the on-chain record matches; `Ok(false)` if it
+    /// exists but points to a different pubkey; `Err(_)` if the lookup failed.
+    pub async fn verify_nip05(
+        &self,
+        nip05: &str,
+        pubkey: PublicKey,
+    ) -> Result<bool, NamecoinLookupError> {
+        let resolved = self.resolve(nip05).await?;
+        Ok(resolved.pubkey == pubkey)
+    }
+}
+
+/// Resolve a parsed identifier via ElectrumX.
+fn resolve_identifier(
+    servers: &[ElectrumxServer],
+    id: &NamecoinIdentifier,
+) -> Result<PublicKey, NamecoinLookupError> {
+    tracing::info!(
+        "Namecoin: resolving '{}' (local_part: '{}')",
+        id.name,
+        id.local_part
+    );
+    let result = electrumx::name_show(servers, &id.name);
+
+    match result {
+        Ok(name_result) => {
+            tracing::info!(
+                "Namecoin: got value for '{}' at height {}: {}",
+                id.name,
+                name_result.height,
+                &name_result.value
+            );
+            match extract_pubkey_from_value(&name_result.value, &id.local_part) {
+                Some(pk) => {
+                    tracing::info!("Namecoin: resolved '{}' → {}", id.name, pk.as_hex_string());
+                    Ok(pk)
+                }
+                None => {
+                    tracing::warn!(
+                        "Namecoin: no pubkey found for local_part '{}' in value: {}",
+                        id.local_part,
+                        &name_result.value
+                    );
+                    Err(NamecoinLookupError::NameNotFound)
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Namecoin: resolution failed for '{}': {}", id.name, e);
+            Err(match e {
+                electrumx::ElectrumxError::NameNotFound => NamecoinLookupError::NameNotFound,
+                electrumx::ElectrumxError::NameExpired => NamecoinLookupError::NameExpired,
+                electrumx::ElectrumxError::ParseError(s) => NamecoinLookupError::Parse(s),
+                other => NamecoinLookupError::ServersUnreachable(other.to_string()),
+            })
+        }
+    }
+}
+
+/// Extract a Nostr pubkey from a Namecoin name's on-chain JSON value.
+///
+/// Supports two value formats:
+///
+/// **Simple format** (pubkey directly in `nostr` field):
+/// ```json
+/// {"nostr": "hexencodedpubkey"}
+/// ```
+///
+/// **Extended NIP-05-like format** (with names mapping):
+/// ```json
+/// {"nostr": {"names": {"alice": "hexencodedpubkey", "_": "hexdefault"}}}
+/// ```
+///
+/// For root lookups (local_part == "_"), falls back to the first available
+/// entry if `_` is not present (fix from Amethyst PR #1771).
+fn extract_pubkey_from_value(value: &str, local_part: &str) -> Option<PublicKey> {
+    let json: serde_json::Value = serde_json::from_str(value).ok()?;
+
+    let nostr_field = json.get("nostr")?;
+
+    // Simple format: {"nostr": "hexkey"}
+    if let Some(hex_str) = nostr_field.as_str() {
+        return pubkey_from_hex(hex_str);
+    }
+
+    // Extended format: {"nostr": {"names": {"user": "hexkey"}}}
+    if let Some(nostr_obj) = nostr_field.as_object() {
+        if let Some(names) = nostr_obj.get("names").and_then(|n| n.as_object()) {
+            // Try the requested local part first
+            if let Some(pk_val) = names.get(local_part) {
+                return pubkey_from_json_value(pk_val);
+            }
+
+            // Try "_" fallback for non-root lookups
+            if local_part != "_" {
+                if let Some(pk_val) = names.get("_") {
+                    return pubkey_from_json_value(pk_val);
+                }
+            } else {
+                // Root lookup: fall back to first available entry when "_" is
+                // absent (Amethyst PR #1771 fix).
+                if let Some((_, first_val)) = names.iter().next() {
+                    return pubkey_from_json_value(first_val);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn pubkey_from_hex(hex_str: &str) -> Option<PublicKey> {
+    PublicKey::try_from_hex_string(hex_str, false).ok()
+}
+
+fn pubkey_from_json_value(val: &serde_json::Value) -> Option<PublicKey> {
+    val.as_str().and_then(pubkey_from_hex)
+}
+
+/// The process-wide default resolver. Shared across the UI and the nip05
+/// verification path.
+pub static NAMECOIN_RESOLVER: once_cell::sync::Lazy<NamecoinResolver> =
+    once_cell::sync::Lazy::new(NamecoinResolver::new);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A known-valid secp256k1 x-only pubkey for test purposes.
+    // `PublicKey::try_from_hex_string` with `false` (don't verify) will accept
+    // arbitrary 32-byte hex; we use distinguishable values.
+    fn hex32(byte: u8) -> String {
+        hex::encode(vec![byte; 32])
+    }
+
+    #[test]
+    fn test_extract_simple_format_invalid_length() {
+        let value = r#"{"nostr": "abcdef"}"#;
+        assert!(extract_pubkey_from_value(value, "_").is_none());
+    }
+
+    #[test]
+    fn test_extract_simple_format_valid() {
+        let hex32 = hex32(0xaa);
+        let value = format!(r#"{{"nostr": "{}"}}"#, hex32);
+        let pk = extract_pubkey_from_value(&value, "_");
+        assert!(pk.is_some());
+    }
+
+    #[test]
+    fn test_extract_extended_format() {
+        let hex32 = hex32(0xbb);
+        let value = format!(r#"{{"nostr": {{"names": {{"m": "{}"}}}}}}"#, hex32);
+
+        // Lookup by name
+        let pk = extract_pubkey_from_value(&value, "m");
+        assert!(pk.is_some());
+
+        // Root lookup should fall back to first entry (PR #1771 fix)
+        let pk_root = extract_pubkey_from_value(&value, "_");
+        assert!(pk_root.is_some());
+    }
+
+    #[test]
+    fn test_extract_with_underscore_key() {
+        let hex_a = hex32(0x11);
+        let hex_b = hex32(0x22);
+        let value = format!(
+            r#"{{"nostr": {{"names": {{"_": "{}", "alice": "{}"}}}}}}"#,
+            hex_a, hex_b
+        );
+
+        let pk_root = extract_pubkey_from_value(&value, "_");
+        assert!(pk_root.is_some());
+        assert_eq!(pk_root.unwrap().as_hex_string(), hex_a);
+
+        let pk_alice = extract_pubkey_from_value(&value, "alice");
+        assert!(pk_alice.is_some());
+        assert_eq!(pk_alice.unwrap().as_hex_string(), hex_b);
+    }
+
+    #[test]
+    fn test_non_root_no_fallback() {
+        // Non-root lookups must NOT fall back to the first entry.
+        let hex = hex32(0x33);
+        let value = format!(r#"{{"nostr": {{"names": {{"m": "{}"}}}}}}"#, hex);
+
+        let pk = extract_pubkey_from_value(&value, "nonexistent");
+        assert!(pk.is_none());
+    }
+}

--- a/gossip-lib/src/nip05.rs
+++ b/gossip-lib/src/nip05.rs
@@ -40,6 +40,32 @@ pub async fn validate_nip05(person: Person) -> Result<(), Error> {
         }
     };
 
+    // Namecoin path: .bit domains are resolved on-chain instead of HTTPS.
+    if domain.ends_with(".bit") {
+        let valid = match crate::namecoin::NAMECOIN_RESOLVER
+            .verify_nip05(&nip05, person.pubkey)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "Namecoin NIP-05 verification error for {}: {}",
+                    nip05,
+                    e
+                );
+                false
+            }
+        };
+        GLOBALS.people.upsert_nip05_validity(
+            &person.pubkey,
+            Some(nip05.clone()),
+            valid,
+            now.0 as u64,
+        )?;
+        GLOBALS.ui_invalidate_person(person.pubkey);
+        return Ok(());
+    }
+
     // Fetch NIP-05
     let nip05file = match fetch_nip05(&user, &domain).await {
         Ok(content) => content,
@@ -101,6 +127,29 @@ pub async fn get_and_follow_nip05(
 ) -> Result<(), Error> {
     // Split their DNS ID
     let (user, domain) = parse_nip05(&nip05)?;
+
+    // Namecoin path: .bit domains resolve on-chain.
+    if domain.ends_with(".bit") {
+        let resolved = crate::namecoin::NAMECOIN_RESOLVER
+            .resolve(&nip05)
+            .await
+            .map_err(|e| -> Error {
+                ErrorKind::General(format!("Namecoin resolve: {e}")).into()
+            })?;
+        let pubkey = resolved.pubkey;
+
+        GLOBALS.people.upsert_nip05_validity(
+            &pubkey,
+            Some(nip05.clone()),
+            true,
+            Unixtime::now().0 as u64,
+        )?;
+
+        GLOBALS.people.follow(&pubkey, true, list, private)?;
+
+        tracing::info!("Followed {} (Namecoin)", &nip05);
+        return Ok(());
+    }
 
     // Fetch NIP-05
     let nip05file = fetch_nip05(&user, &domain).await?;

--- a/gossip-lib/src/storage/mod.rs
+++ b/gossip-lib/src/storage/mod.rs
@@ -916,6 +916,12 @@ impl Storage {
     );
     def_setting!(blossom_servers, b"blossom_servers", String, "".to_string());
     def_setting!(undo_send_seconds, b"undo_send_seconds", u64, 10);
+    def_setting!(
+        namecoin_socks5_proxy,
+        b"namecoin_socks5_proxy",
+        String,
+        "".to_owned()
+    );
 
     // -------------------------------------------------------------------
 


### PR DESCRIPTION
Add censorship-resistant NIP-05 identity resolution using the Namecoin
blockchain. Users can search for `.bit` domains (e.g. `m@testls.bit`),
bare domains (`testls.bit`), or direct Namecoin names (`d/testls`,
`id/alice`) and gossip will resolve the pubkey mapping via ElectrumX
instead of HTTPS.

Resolution uses the standard Electrum protocol (scripthash-based
lookups):
- Build canonical name index script matching ElectrumX-NMC indexing:
  `OP_NAME_UPDATE + push(name) + push(empty) + OP_2DROP + OP_DROP + OP_RETURN`
- Compute reversed SHA-256 scripthash
- Query `blockchain.scripthash.get_history` for the name's tx history
- Fetch and parse the `NAME_UPDATE` script from the latest transaction output
- Extract the Nostr pubkey from the name's on-chain JSON value
- Check name expiry via `blockchain.headers.subscribe` (36000 block limit)

Search bar integration (`gossip-bin/src/ui/search.rs`):
- Detects Namecoin identifiers as the user submits a search
- Runs resolution in parallel with the existing local/relay search on
  `GLOBALS.runtime`, so the normal flow is never blocked
- Shows state under the search bar:
  - `🔄 Resolving via Namecoin blockchain…` with a spinner while in flight
  - `🔗 Namecoin (d/name) <npub-short>` on success, clickable to the
    Person page
  - Distinct error lines for name-not-found, name-expired, and
    servers-unreachable

NIP-05 verification hook (`gossip-lib/src/nip05.rs`):
- Both `validate_nip05` and `get_and_follow_nip05` short-circuit on
  `.bit` domains and verify on-chain via `NAMECOIN_RESOLVER`
- All non-`.bit` NIP-05 lookups use the existing HTTPS path unchanged

Supports both `d/` (domain) and `id/` (identity) Namecoin namespaces,
simple and extended NIP-05-like value formats with relay hints,
LRU caching with 1h TTL, self-signed TLS certificates, and background
resolution via `tokio::spawn` on gossip's shared runtime so the UI
thread never blocks.

### New files
- `gossip-lib/src/namecoin/mod.rs` — `NamecoinResolver`, public API,
  JSON → pubkey extraction, default server list
- `gossip-lib/src/namecoin/electrumx.rs` — ElectrumX JSON-RPC over TLS,
  scripthash + `NAME_UPDATE` parsing, expiry check
- `gossip-lib/src/namecoin/identifier.rs` — parser for `d/name`,
  `id/name`, `user@domain.bit`, bare `domain.bit`
- `gossip-lib/src/namecoin/cache.rs` — LRU + 1h TTL cache (VecDeque
  for O(1) eviction)

### Modified
- `gossip-lib/Cargo.toml`: adds `once_cell`, `rustls 0.23` (default
  features off; `std,tls12,logging,ring` — `ring` already resolved via
  reqwest)
- `gossip-lib/src/lib.rs`: `pub mod namecoin;`
- `gossip-lib/src/nip05.rs`: `.bit` short-circuit → Namecoin resolver
- `gossip-bin/src/ui/mod.rs`: `namecoin_search_state`,
  `namecoin_last_query` fields on `GossipUi`
- `gossip-bin/src/ui/search.rs`: `NamecoinSearchState` state machine
  + status renderer

### Testing
- `cargo check --all-targets` — clean
- `cargo build --release -p gossip` — clean
- `cargo test -p gossip-lib namecoin::` — 20/20 pass, no network
  tests (identifier parsing, cache eviction, JSON value extraction)
- Manual: desktop (macOS), resolves `d/testls`, `m@testls.bit`,
  and bare `testls.bit` against the default ElectrumX-NMC server set.

### Known limitations / TODOs
- **SOCKS5 proxy:** disabled by default. Set `namecoin_socks5_proxy`
  (e.g. `127.0.0.1:9050`) to route Namecoin ElectrumX lookups
  through Tor or any SOCKS5 proxy. Empty string = direct connect.
- **TLS verifier:** uses an `AcceptAnyCert` verifier for the ElectrumX
  connection only (ElectrumX-NMC servers commonly use self-signed
  certs). All other TLS in gossip (reqwest, tungstenite) is unchanged.
- **Cache** is in-process only; no persistence across restarts.

### Default ElectrumX servers
- `electrumx.testls.space:50002`
- `nmc2.bitcoins.sk:57002`
- `46.229.238.187:57002`

Failures fall through to the next server; `ServersUnreachable` is only
returned when every server fails with a connection error (definitive
`NameNotFound` / `NameExpired` short-circuit immediately).

### Credits
Ported from the notedeck implementation:
https://github.com/damus-io/notedeck/pull/1314

Which was in turn ported from Amethyst:
https://github.com/vitorpamplona/amethyst/pull/1734

